### PR TITLE
Fix typos for docker commands

### DIFF
--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -8,9 +8,9 @@ Download the image tar from https://drive.google.com/file/d/1gxXalk9O0p9eu1YkIJc
 
 ```
 docker load --input shopping_final_0712.tar
-docker run -name shopping -p 7770:80 -d shopping_final_0712
+docker run --name shopping -p 7770:80 -d shopping_final_0712
 docker exec shopping /var/www/magento2/bin/magento setup:store-config:set --base-url="http://<your-server-hostname>:7770/"
-docker exec shopping /var/www/magento2/bin/magento cache:flush"
+docker exec shopping /var/www/magento2/bin/magento cache:flush
 ```
 Now you can visit `http://<your-server-hostname>:7770`.
 
@@ -21,9 +21,9 @@ Download the image tar from https://drive.google.com/file/d/1See0ZhJRw0WTTL9y8hF
 
 ```
 docker load --input shopping_admin_final_0719.tar
-docker run -name shopping_admin -p 7780:80 -d shopping_admin_final_0719
+docker run --name shopping_admin -p 7780:80 -d shopping_admin_final_0719
 docker exec shopping_admin /var/www/magento2/bin/magento setup:store-config:set --base-url="http://<your-server-hostname>:7780/"
-docker exec shopping_admin /var/www/magento2/bin/magento cache:flush"
+docker exec shopping_admin /var/www/magento2/bin/magento cache:flush
 ```
 Now you can visit `http://<your-server-hostname>:7780/admin`.
 
@@ -34,7 +34,7 @@ Download the image tar from https://drive.google.com/file/d/17Qpp1iu_mPqzgO_73Z9
 
 ```
 docker load --input postmill-populated-exposed-withimg.tar
-docker run -name forum -p 9999:80 -d postmill-populated-exposed-withimg
+docker run --name forum -p 9999:80 -d postmill-populated-exposed-withimg
 ```
 Now you can visit `http://<your-server-hostname>:9999/`.
 
@@ -45,7 +45,7 @@ Download the image tar from https://drive.google.com/file/d/19W8qM0DPyRvWCLyQe0q
 
 ```
 docker load --input gitlab-populated-final-port8023.tar
-docker run -name gitlab -d -p 8023:8023 gitlab-populated-final-port8023 /opt/gitlab/embedded/bin/runsvdir-start
+docker run --name gitlab -d -p 8023:8023 gitlab-populated-final-port8023 /opt/gitlab/embedded/bin/runsvdir-start
 ```
 It might take 5 mins to start and then you can visit `http://<your-server-hostname>:8023/explore`.
 


### PR DESCRIPTION
I noticed that there are several typos in the docker command provided. Please confirm the correctness of the modification.