### PR TITLE
Improve current viewport filtering

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -3,8 +3,6 @@ import json
 from typing import Any
 
 import tiktoken
-from beartype import beartype
-from beartype.door import is_bearable
 
 from agent.prompts import *
 from browser_env import Trajectory
@@ -48,11 +46,9 @@ class TeacherForcingAgent(Agent):
     def __init__(self) -> None:
         super().__init__()
 
-    @beartype
     def set_action_set_tag(self, tag: str) -> None:
         self.action_set_tag = tag
 
-    @beartype
     def set_actions(self, action_seq: str | list[str]) -> None:
         if isinstance(action_seq, str):
             action_strs = action_seq.strip().split("\n")
@@ -79,14 +75,12 @@ class TeacherForcingAgent(Agent):
 
         self.actions: list[Action] = actions
 
-    @beartype
     def next_action(
         self, trajectory: Trajectory, intent: str, meta_data: Any
     ) -> Action:
         """Predict the next action given the observation"""
         return self.actions.pop(0)
 
-    @beartype
     def reset(
         self,
         test_config_file: str,
@@ -113,11 +107,9 @@ class PromptAgent(Agent):
         self.prompt_constructor = prompt_constructor
         self.action_set_tag = action_set_tag
 
-    @beartype
     def set_action_set_tag(self, tag: str) -> None:
         self.action_set_tag = tag
 
-    @beartype
     def next_action(
         self, trajectory: Trajectory, intent: str, meta_data: dict[str, Any]
     ) -> Action:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -3,6 +3,7 @@ import json
 from typing import Any
 
 import tiktoken
+from beartype import beartype
 
 from agent.prompts import *
 from browser_env import Trajectory
@@ -96,6 +97,7 @@ class TeacherForcingAgent(Agent):
 class PromptAgent(Agent):
     """prompt-based agent that emits action given the history"""
 
+    @beartype
     def __init__(
         self,
         action_set_tag: str,
@@ -110,6 +112,7 @@ class PromptAgent(Agent):
     def set_action_set_tag(self, tag: str) -> None:
         self.action_set_tag = tag
 
+    @beartype
     def next_action(
         self, trajectory: Trajectory, intent: str, meta_data: dict[str, Any]
     ) -> Action:

--- a/agent/prompts/prompt_constructor.py
+++ b/agent/prompts/prompt_constructor.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any, TypedDict
 
 import tiktoken
-from beartype import beartype
 
 from browser_env import Action, ActionParsingError, Trajectory
 from browser_env.env_config import URL_MAPPINGS
@@ -38,7 +37,6 @@ class PromptConstructor(object):
         self.instruction: Instruction = instruction
         self.tokenizer = tokenizer
 
-    @beartype
     def get_lm_api_input(
         self, intro: str, examples: list[tuple[str, str]], current: str
     ) -> APIInput:
@@ -84,7 +82,6 @@ class PromptConstructor(object):
                 f"Provider {self.lm_config.provider} not implemented"
             )
 
-    @beartype
     def construct(
         self,
         trajectory: Trajectory,
@@ -93,7 +90,6 @@ class PromptConstructor(object):
     ) -> APIInput:
         raise NotImplementedError
 
-    @beartype
     def map_url_to_real(self, url: str) -> str:
         """Map the urls to their real world counterparts"""
         for i, j in URL_MAPPINGS.items():
@@ -101,7 +97,6 @@ class PromptConstructor(object):
                 url = url.replace(i, j)
         return url
 
-    @beartype
     def map_url_to_local(self, url: str) -> str:
         """Map the urls to their local counterparts"""
         for i, j in URL_MAPPINGS.items():
@@ -109,11 +104,9 @@ class PromptConstructor(object):
                 url = url.replace(j, i)
         return url
 
-    @beartype
     def _extract_action(self, response: str) -> str:
         raise NotImplementedError
 
-    @beartype
     def extract_action(self, response: str) -> str:
         response = self._extract_action(response)
         response = self.map_url_to_local(response)
@@ -131,7 +124,6 @@ class DirectPromptConstructor(PromptConstructor):
     ):
         super().__init__(instruction_path, lm_config, tokenizer)
 
-    @beartype
     def construct(
         self,
         trajectory: Trajectory,
@@ -167,7 +159,6 @@ class DirectPromptConstructor(PromptConstructor):
         prompt = self.get_lm_api_input(intro, examples, current)
         return prompt
 
-    @beartype
     def _extract_action(self, response: str) -> str:
         action_splitter = self.instruction["meta_data"]["action_splitter"]
         pattern = rf"{action_splitter}(.*?){action_splitter}"
@@ -192,7 +183,6 @@ class CoTPromptConstructor(PromptConstructor):
         super().__init__(instruction_path, lm_config, tokenizer)
         self.answer_phrase = self.instruction["meta_data"]["answer_phrase"]
 
-    @beartype
     def construct(
         self,
         trajectory: Trajectory,
@@ -225,7 +215,6 @@ class CoTPromptConstructor(PromptConstructor):
         prompt = self.get_lm_api_input(intro, examples, current)
         return prompt
 
-    @beartype
     def _extract_action(self, response: str) -> str:
         # find the first occurence of action
         action_splitter = self.instruction["meta_data"]["action_splitter"]

--- a/browser_env/actions.py
+++ b/browser_env/actions.py
@@ -12,8 +12,6 @@ from typing import Any, TypedDict, Union, cast
 
 import numpy as np
 import numpy.typing as npt
-from beartype import beartype
-from beartype.door import is_bearable
 from gymnasium import spaces
 from playwright._impl._api_structures import ViewportSize
 from playwright.async_api import BrowserContext as ABrowserContext
@@ -55,7 +53,6 @@ from browser_env.processors import (
 )
 
 
-@beartype
 def is_in_viewport(
     element: Locator, viewport: ViewportSize, threshold: float = 0.3
 ) -> bool:
@@ -75,7 +72,6 @@ def is_in_viewport(
     return ratio > threshold
 
 
-@beartype
 async def async_is_in_viewport(
     element: ALocator, viewport: ViewportSize, threshold: float = 0.3
 ) -> bool:
@@ -111,7 +107,6 @@ class Action(TypedDict):
     raw_prediction: str  # raw prediction from the model
 
 
-@beartype
 def action2str(
     action: Action, action_set_tag: str, semantic_element: str = ""
 ) -> str:
@@ -274,7 +269,6 @@ class ActionTypes(IntEnum):
         return f"ACTION_TYPES.{self.name}"
 
 
-@beartype
 def is_equivalent(a: Action, b: Action) -> bool:
     """Return True if two actions are equal."""
     if a["action_type"] != b["action_type"]:
@@ -338,12 +332,11 @@ _role2id: dict[RolesType, int] = {
 _id2role: list[RolesType] = sorted(_role2id, key=_role2id.get)  # type: ignore[arg-type]
 
 
-@beartype
 def _keys2ids(keys: list[int | str] | str) -> list[int]:
     return list(
         map(
             lambda key: _key2id[str(key)]
-            if is_bearable(key, str)
+            if isinstance(key, str)
             else int(key),
             keys,
         )
@@ -424,7 +417,6 @@ def create_random_action() -> Action:
     }
 
 
-@beartype
 def create_none_action() -> Action:
     """Return a valid action object that does nothing."""
     return {
@@ -445,14 +437,12 @@ def create_none_action() -> Action:
     }
 
 
-@beartype
 def create_stop_action(answer: str) -> Action:
     action = create_none_action()
     action.update({"action_type": ActionTypes.STOP, "answer": answer})
     return action
 
 
-@beartype
 def create_scroll_action(direction: str) -> Action:
     """Return the playwright action"""
     assert direction in ["up", "down"]
@@ -466,7 +456,6 @@ def create_scroll_action(direction: str) -> Action:
     return action
 
 
-@beartype
 def create_mouse_hover_action(
     left: float | None = None, top: float | None = None
 ) -> Action:
@@ -481,7 +470,6 @@ def create_mouse_hover_action(
     return action
 
 
-@beartype
 def create_key_press_action(key_comb: str) -> Action:
     """Return the key press action"""
 
@@ -504,7 +492,6 @@ def create_key_press_action(key_comb: str) -> Action:
     return action
 
 
-@beartype
 def create_page_focus_action(page_number: int) -> Action:
     """Return a valid action object with type PAGE_FOCUS."""
     action = create_none_action()
@@ -517,7 +504,6 @@ def create_page_focus_action(page_number: int) -> Action:
     return action
 
 
-@beartype
 def create_new_tab_action() -> Action:
     """Return a valid action object with type NEW_TAB."""
     action = create_none_action()
@@ -529,7 +515,6 @@ def create_new_tab_action() -> Action:
     return action
 
 
-@beartype
 def create_go_back_action() -> Action:
     """Return a valid action object with type GO_BACK."""
     action = create_none_action()
@@ -541,7 +526,6 @@ def create_go_back_action() -> Action:
     return action
 
 
-@beartype
 def create_go_forward_action() -> Action:
     """Return a valid action object with type GO_FORWARD."""
     action = create_none_action()
@@ -553,7 +537,6 @@ def create_go_forward_action() -> Action:
     return action
 
 
-@beartype
 def create_goto_url_action(url: str) -> Action:
     """Return a valid action object with type GOTO_URL."""
     action = create_none_action()
@@ -566,7 +549,6 @@ def create_goto_url_action(url: str) -> Action:
     return action
 
 
-@beartype
 def create_page_close_action() -> Action:
     """Return a valid action object with type PAGE_CLOSE."""
     action = create_none_action()
@@ -578,7 +560,6 @@ def create_page_close_action() -> Action:
     return action
 
 
-@beartype
 def create_mouse_click_action(
     left: float | None = None, top: float | None = None
 ) -> Action:
@@ -602,7 +583,6 @@ def create_mouse_click_action(
     return action
 
 
-@beartype
 def create_keyboard_type_action(keys: list[int | str] | str) -> Action:
     """Return a valid action object with type TYPE."""
     action = create_none_action()
@@ -615,7 +595,6 @@ def create_keyboard_type_action(keys: list[int | str] | str) -> Action:
     return action
 
 
-@beartype
 def create_click_action(
     element_id: str = "",
     element_role: RolesType = "link",
@@ -637,7 +616,6 @@ def create_click_action(
     return action
 
 
-@beartype
 def create_hover_action(
     element_id: str = "",
     element_role: RolesType = "link",
@@ -659,7 +637,6 @@ def create_hover_action(
     return action
 
 
-@beartype
 def create_type_action(
     text: str,
     element_id: str = "",
@@ -683,7 +660,6 @@ def create_type_action(
     return action
 
 
-@beartype
 def create_check_action(pw_code: str) -> Action:
     action = create_none_action()
     action.update(
@@ -695,7 +671,6 @@ def create_check_action(pw_code: str) -> Action:
     return action
 
 
-@beartype
 def create_select_option_action(
     pw_code: str,
 ) -> Action:
@@ -709,7 +684,6 @@ def create_select_option_action(
     return action
 
 
-@beartype
 def create_focus_action(
     element_role: RolesType, element_name: str = "", nth: int = 0
 ) -> Action:
@@ -728,7 +702,6 @@ def create_focus_action(
     return action
 
 
-@beartype
 def create_focus_and_click_action(
     element_role: RolesType, element_name: str = "", nth: int = 0
 ) -> Action:
@@ -748,7 +721,6 @@ def create_focus_and_click_action(
     return action
 
 
-@beartype
 def create_focus_and_type_action(
     keys: list[int | str] | str,
     element_role: RolesType,
@@ -771,7 +743,6 @@ def create_focus_and_type_action(
     return action
 
 
-@beartype
 def execute_scroll(direction: str, page: Page) -> None:
     # perform the action
     # code from natbot
@@ -785,7 +756,6 @@ def execute_scroll(direction: str, page: Page) -> None:
         )
 
 
-@beartype
 async def aexecute_scroll(direction: str, page: APage) -> None:
     # perform the action
     # code from natbot
@@ -799,19 +769,16 @@ async def aexecute_scroll(direction: str, page: APage) -> None:
         )
 
 
-@beartype
 def execute_key_press(key: str, page: Page) -> None:
     """Press a key."""
     page.keyboard.press(key)
 
 
-@beartype
 async def aexecute_key_press(key: str, page: APage) -> None:
     """Press a key."""
     await page.keyboard.press(key)
 
 
-@beartype
 def execute_mouse_hover(left: float, top: float, page: Page) -> None:
     """Click at coordinates (left, top)."""
     viewport_size = page.viewport_size
@@ -821,7 +788,6 @@ def execute_mouse_hover(left: float, top: float, page: Page) -> None:
     )
 
 
-@beartype
 async def aexecute_mouse_hover(left: float, top: float, page: APage) -> None:
     """Click at coordinates (left, top)."""
     viewport_size = page.viewport_size
@@ -840,7 +806,6 @@ def execute_mouse_click(left: float, top: float, page: Page) -> None:
     )
 
 
-@beartype
 async def aexecute_mouse_click(left: float, top: float, page: APage) -> None:
     """Click at coordinates (left, top)."""
     viewport_size = page.viewport_size
@@ -850,19 +815,16 @@ async def aexecute_mouse_click(left: float, top: float, page: APage) -> None:
     )
 
 
-@beartype
 def execute_keyboard_type(text: str, page: Page) -> None:
     """Fill the focused element with text."""
     page.keyboard.type(text)
 
 
-@beartype
 async def aexecute_keyboard_type(text: str, page: APage) -> None:
     """Fill the focused element with text."""
     await page.keyboard.type(text)
 
 
-@beartype
 def execute_click_current(page: Page) -> None:
     """Click at the current mouse position."""
     locators = page.locator("*:focus")
@@ -874,7 +836,6 @@ def execute_click_current(page: Page) -> None:
     locators.click()
 
 
-@beartype
 async def aexecute_click_current(page: APage) -> None:
     """Click at the current mouse position."""
     locators = page.locator("*:focus")
@@ -889,21 +850,18 @@ async def aexecute_click_current(page: APage) -> None:
     await page.wait_for_load_state("load")
 
 
-@beartype
 def execute_type(keys: list[int], page: Page) -> None:
     """Send keystrokes to the focused element."""
     text = "".join([_id2key[key] for key in keys])
     page.keyboard.type(text)
 
 
-@beartype
 async def aexecute_type(keys: list[int], page: APage) -> None:
     """Send keystrokes to the focused element."""
     text = "".join([_id2key[key] for key in keys])
     await page.keyboard.type(text)
 
 
-@beartype
 def execute_focus(
     element_role: int, element_name: str, nth: int, page: Page
 ) -> None:
@@ -940,7 +898,6 @@ def execute_focus(
     element_location_list[nth][0].focus()
 
 
-@beartype
 async def aexecute_focus(
     element_role: int, element_name: str, nth: int, page: APage
 ) -> None:
@@ -977,7 +934,6 @@ async def aexecute_focus(
     await element_location_list[nth][0].focus()
 
 
-@beartype
 def locate(locator_calls: list[ParsedPlaywrightCode], page: Page) -> Locator:
     locator = page
     for call in locator_calls:
@@ -988,7 +944,6 @@ def locate(locator_calls: list[ParsedPlaywrightCode], page: Page) -> Locator:
     return locator  # type: ignore[return-value]
 
 
-@beartype
 async def alocate(
     locator_calls: list[ParsedPlaywrightCode], page: APage
 ) -> ALocator:
@@ -1001,7 +956,6 @@ async def alocate(
     return locator  # type: ignore[return-value]
 
 
-@beartype
 def execute_playwright_click(
     locator_code: list[ParsedPlaywrightCode],
     page: Page,
@@ -1014,7 +968,6 @@ def execute_playwright_click(
     locator.click(*pw_action_args, **pw_action_kwargs)
 
 
-@beartype
 async def aexecute_playwright_click(
     locator_code: list[ParsedPlaywrightCode],
     page: APage,
@@ -1027,7 +980,6 @@ async def aexecute_playwright_click(
     await locator.click(*pw_action_args, **pw_action_kwargs)
 
 
-@beartype
 def execute_playwright_hover(
     locator_code: list[ParsedPlaywrightCode], page: Page
 ) -> None:
@@ -1037,7 +989,6 @@ def execute_playwright_hover(
     locator.hover()
 
 
-@beartype
 async def aexecute_playwright_hover(
     locator_code: list[ParsedPlaywrightCode], page: APage
 ) -> None:
@@ -1047,7 +998,6 @@ async def aexecute_playwright_hover(
     await locator.hover()
 
 
-@beartype
 def execute_playwright_type(
     text: str,
     locator_code: list[ParsedPlaywrightCode],
@@ -1061,7 +1011,6 @@ def execute_playwright_type(
     locator.type(*pw_action_args, **pw_action_kwargs)
 
 
-@beartype
 async def aexecute_playwright_type(
     text: str,
     locator_code: list[ParsedPlaywrightCode],
@@ -1075,7 +1024,6 @@ async def aexecute_playwright_type(
     await locator.type(*pw_action_args, **pw_action_kwargs)
 
 
-@beartype
 def execute_playwright_select_option(
     locator_code: list[ParsedPlaywrightCode],
     page: Page,
@@ -1087,7 +1035,6 @@ def execute_playwright_select_option(
     locator.select_option(*pw_action_args, **pw_action_kwargs)
 
 
-@beartype
 async def aexecute_playwright_select_option(
     locator_code: list[ParsedPlaywrightCode],
     page: APage,
@@ -1099,7 +1046,6 @@ async def aexecute_playwright_select_option(
     await locator.select_option(*pw_action_args, **pw_action_kwargs)
 
 
-@beartype
 def execute_playwright_check(
     locator_code: list[ParsedPlaywrightCode], page: Page
 ) -> None:
@@ -1108,7 +1054,6 @@ def execute_playwright_check(
     locator.check()
 
 
-@beartype
 async def aexecute_playwright_check(
     locator_code: list[ParsedPlaywrightCode], page: APage
 ) -> None:
@@ -1117,7 +1062,6 @@ async def aexecute_playwright_check(
     await locator.check()
 
 
-@beartype
 def execute_action(
     action: Action,
     page: Page,
@@ -1252,7 +1196,6 @@ def execute_action(
     return page
 
 
-@beartype
 async def aexecute_action(
     action: Action, page: APage, browser_ctx: ABrowserContext
 ) -> APage:
@@ -1383,7 +1326,6 @@ async def aexecute_action(
     return page
 
 
-@beartype
 def parse_playwright_code(code: str) -> list[ParsedPlaywrightCode]:
     # extract function calls
     if not code.startswith("page."):
@@ -1444,14 +1386,12 @@ def parse_playwright_code(code: str) -> list[ParsedPlaywrightCode]:
     return parsed_chain
 
 
-@beartype
 class ActionParsingError(Exception):
     def __init__(self, message: str) -> None:
         self.message = message
         super().__init__(self.message)
 
 
-@beartype
 def create_playwright_action(playwright_code: str) -> Action:
     """Main function to return individual playwright action"""
     # get the last action
@@ -1524,7 +1464,6 @@ def create_playwright_action(playwright_code: str) -> Action:
     raise ActionParsingError(f"Unknown playwright action {action}")
 
 
-@beartype
 def create_id_based_action(action_str: str) -> Action:
     """Main function to return individual id based action"""
     action_str = action_str.strip()

--- a/browser_env/actions.py
+++ b/browser_env/actions.py
@@ -12,6 +12,7 @@ from typing import Any, TypedDict, Union, cast
 
 import numpy as np
 import numpy.typing as npt
+from beartype import beartype
 from gymnasium import spaces
 from playwright._impl._api_structures import ViewportSize
 from playwright.async_api import BrowserContext as ABrowserContext
@@ -107,6 +108,7 @@ class Action(TypedDict):
     raw_prediction: str  # raw prediction from the model
 
 
+@beartype
 def action2str(
     action: Action, action_set_tag: str, semantic_element: str = ""
 ) -> str:
@@ -156,6 +158,7 @@ def action2str(
     return action_str
 
 
+@beartype
 def action2create_function(action: Action) -> str:
     match (action["action_type"]):
         case ActionTypes.NONE:
@@ -269,6 +272,7 @@ class ActionTypes(IntEnum):
         return f"ACTION_TYPES.{self.name}"
 
 
+@beartype
 def is_equivalent(a: Action, b: Action) -> bool:
     """Return True if two actions are equal."""
     if a["action_type"] != b["action_type"]:
@@ -343,6 +347,7 @@ def _keys2ids(keys: list[int | str] | str) -> list[int]:
     )
 
 
+@beartype
 def get_action_space() -> spaces.Dict:
     """Return the space of serialized actions."""
     space = spaces.Dict(
@@ -381,6 +386,7 @@ def get_action_space() -> spaces.Dict:
     return space
 
 
+@beartype
 def create_random_action() -> Action:
     """Return a random action."""
     return {
@@ -417,6 +423,7 @@ def create_random_action() -> Action:
     }
 
 
+@beartype
 def create_none_action() -> Action:
     """Return a valid action object that does nothing."""
     return {
@@ -437,12 +444,14 @@ def create_none_action() -> Action:
     }
 
 
+@beartype
 def create_stop_action(answer: str) -> Action:
     action = create_none_action()
     action.update({"action_type": ActionTypes.STOP, "answer": answer})
     return action
 
 
+@beartype
 def create_scroll_action(direction: str) -> Action:
     """Return the playwright action"""
     assert direction in ["up", "down"]
@@ -456,6 +465,7 @@ def create_scroll_action(direction: str) -> Action:
     return action
 
 
+@beartype
 def create_mouse_hover_action(
     left: float | None = None, top: float | None = None
 ) -> Action:
@@ -470,6 +480,7 @@ def create_mouse_hover_action(
     return action
 
 
+@beartype
 def create_key_press_action(key_comb: str) -> Action:
     """Return the key press action"""
 
@@ -492,6 +503,7 @@ def create_key_press_action(key_comb: str) -> Action:
     return action
 
 
+@beartype
 def create_page_focus_action(page_number: int) -> Action:
     """Return a valid action object with type PAGE_FOCUS."""
     action = create_none_action()
@@ -504,6 +516,7 @@ def create_page_focus_action(page_number: int) -> Action:
     return action
 
 
+@beartype
 def create_new_tab_action() -> Action:
     """Return a valid action object with type NEW_TAB."""
     action = create_none_action()
@@ -515,6 +528,7 @@ def create_new_tab_action() -> Action:
     return action
 
 
+@beartype
 def create_go_back_action() -> Action:
     """Return a valid action object with type GO_BACK."""
     action = create_none_action()
@@ -526,6 +540,7 @@ def create_go_back_action() -> Action:
     return action
 
 
+@beartype
 def create_go_forward_action() -> Action:
     """Return a valid action object with type GO_FORWARD."""
     action = create_none_action()
@@ -537,6 +552,7 @@ def create_go_forward_action() -> Action:
     return action
 
 
+@beartype
 def create_goto_url_action(url: str) -> Action:
     """Return a valid action object with type GOTO_URL."""
     action = create_none_action()
@@ -549,6 +565,7 @@ def create_goto_url_action(url: str) -> Action:
     return action
 
 
+@beartype
 def create_page_close_action() -> Action:
     """Return a valid action object with type PAGE_CLOSE."""
     action = create_none_action()
@@ -560,6 +577,7 @@ def create_page_close_action() -> Action:
     return action
 
 
+@beartype
 def create_mouse_click_action(
     left: float | None = None, top: float | None = None
 ) -> Action:
@@ -583,6 +601,7 @@ def create_mouse_click_action(
     return action
 
 
+@beartype
 def create_keyboard_type_action(keys: list[int | str] | str) -> Action:
     """Return a valid action object with type TYPE."""
     action = create_none_action()
@@ -595,6 +614,7 @@ def create_keyboard_type_action(keys: list[int | str] | str) -> Action:
     return action
 
 
+@beartype
 def create_click_action(
     element_id: str = "",
     element_role: RolesType = "link",
@@ -616,6 +636,7 @@ def create_click_action(
     return action
 
 
+@beartype
 def create_hover_action(
     element_id: str = "",
     element_role: RolesType = "link",
@@ -637,6 +658,7 @@ def create_hover_action(
     return action
 
 
+@beartype
 def create_type_action(
     text: str,
     element_id: str = "",
@@ -660,6 +682,7 @@ def create_type_action(
     return action
 
 
+@beartype
 def create_check_action(pw_code: str) -> Action:
     action = create_none_action()
     action.update(
@@ -684,6 +707,7 @@ def create_select_option_action(
     return action
 
 
+@beartype
 def create_focus_action(
     element_role: RolesType, element_name: str = "", nth: int = 0
 ) -> Action:
@@ -702,6 +726,7 @@ def create_focus_action(
     return action
 
 
+@beartype
 def create_focus_and_click_action(
     element_role: RolesType, element_name: str = "", nth: int = 0
 ) -> Action:
@@ -721,6 +746,7 @@ def create_focus_and_click_action(
     return action
 
 
+@beartype
 def create_focus_and_type_action(
     keys: list[int | str] | str,
     element_role: RolesType,
@@ -1392,6 +1418,7 @@ class ActionParsingError(Exception):
         super().__init__(self.message)
 
 
+@beartype
 def create_playwright_action(playwright_code: str) -> Action:
     """Main function to return individual playwright action"""
     # get the last action
@@ -1464,6 +1491,7 @@ def create_playwright_action(playwright_code: str) -> Action:
     raise ActionParsingError(f"Unknown playwright action {action}")
 
 
+@beartype
 def create_id_based_action(action_str: str) -> Action:
     """Main function to return individual id based action"""
     action_str = action_str.strip()

--- a/browser_env/async_envs.py
+++ b/browser_env/async_envs.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
-from beartype import beartype
 from gymnasium import Env
 from gymnasium.spaces import Box, Text
 from playwright.async_api import Page, ViewportSize, async_playwright
@@ -23,7 +22,6 @@ class AsyncScriptBrowserEnv(Env[npt.NDArray[np.uint8], Action]):
     and observation space is the html content of the page.
     """
 
-    @beartype
     def __init__(
         self,
         max_page_length: int = 2048,
@@ -46,7 +44,6 @@ class AsyncScriptBrowserEnv(Env[npt.NDArray[np.uint8], Action]):
         self.timeout = timeout
         self.viewport_size = viewport_size
 
-    @beartype
     async def setup(self, config_file: Path | None = None) -> None:
         self.context_manager = async_playwright()
         self.playwright = await self.context_manager.__aenter__()
@@ -73,7 +70,6 @@ class AsyncScriptBrowserEnv(Env[npt.NDArray[np.uint8], Action]):
         if start_url:
             await self.page.goto(start_url)
 
-    @beartype
     async def areset(
         self,
         *,
@@ -104,7 +100,6 @@ class AsyncScriptBrowserEnv(Env[npt.NDArray[np.uint8], Action]):
             {"page": DetachedPage(self.page.url, content)},
         )
 
-    @beartype
     def reset(
         self,
         *,
@@ -120,7 +115,6 @@ class AsyncScriptBrowserEnv(Env[npt.NDArray[np.uint8], Action]):
     def close(self) -> None:
         asyncio.run(self.aclose())
 
-    @beartype
     async def astep(
         self, action: Action
     ) -> tuple[npt.NDArray[np.uint8], float, bool, bool, dict[str, object]]:
@@ -153,7 +147,6 @@ class AsyncScriptBrowserEnv(Env[npt.NDArray[np.uint8], Action]):
             },
         )
 
-    @beartype
     def step(
         self, action: Action
     ) -> tuple[npt.NDArray[np.uint8], float, bool, bool, dict[str, object]]:

--- a/browser_env/auto_login.py
+++ b/browser_env/auto_login.py
@@ -3,7 +3,6 @@ import glob
 from itertools import combinations
 from pathlib import Path
 
-from beartype import beartype
 from playwright.sync_api import sync_playwright
 
 from browser_env.env_config import (
@@ -18,7 +17,6 @@ HEADLESS = True
 SLOW_MO = 0
 
 
-@beartype
 def is_expired(
     storage_state: Path, url: str, keyword: str, url_exact: bool = True
 ) -> bool:
@@ -44,7 +42,6 @@ def is_expired(
             return url not in d_url
 
 
-@beartype
 def renew_comb(comb: list[str]) -> None:
     context_manager = sync_playwright()
     playwright = context_manager.__enter__()
@@ -91,7 +88,6 @@ def renew_comb(comb: list[str]) -> None:
     context_manager.__exit__()
 
 
-@beartype
 def main() -> None:
     sites = ["gitlab", "shopping", "shopping_admin", "reddit"]
     urls = [

--- a/browser_env/envs.py
+++ b/browser_env/envs.py
@@ -8,6 +8,8 @@ from typing import Any, Union
 
 import numpy as np
 import numpy.typing as npt
+from beartype import beartype
+from beartype.door import is_bearable
 from gymnasium import Env
 from gymnasium.spaces import Box, Text
 from playwright.sync_api import (
@@ -71,6 +73,7 @@ class ScriptBrowserEnv(Env[dict[str, Observation], Action]):
     and observation space is the html content of the page.
     """
 
+    @beartype
     def __init__(
         self,
         max_page_length: int = 8192,
@@ -118,6 +121,7 @@ class ScriptBrowserEnv(Env[dict[str, Observation], Action]):
             self.observation_handler.get_observation_space()
         )
 
+    @beartype
     def setup(self, config_file: Path | None = None) -> None:
         self.context_manager = sync_playwright()
         self.playwright = self.context_manager.__enter__()
@@ -177,6 +181,7 @@ class ScriptBrowserEnv(Env[dict[str, Observation], Action]):
         metadata = self.observation_handler.get_observation_metadata()
         return metadata
 
+    @beartype
     def reset(
         self,
         *,

--- a/browser_env/envs.py
+++ b/browser_env/envs.py
@@ -8,7 +8,6 @@ from typing import Any, Union
 
 import numpy as np
 import numpy.typing as npt
-from beartype import beartype
 from gymnasium import Env
 from gymnasium.spaces import Box, Text
 from playwright.sync_api import (
@@ -39,7 +38,6 @@ class PlaywrightScript:
     value: str | None = None  # avatar movie, Enter
 
 
-@beartype
 def parse_action(action: str) -> PlaywrightScript:
     splitted = action.strip().split(" ")
     assert len(splitted) >= 2
@@ -73,7 +71,6 @@ class ScriptBrowserEnv(Env[dict[str, Observation], Action]):
     and observation space is the html content of the page.
     """
 
-    @beartype
     def __init__(
         self,
         max_page_length: int = 8192,
@@ -121,7 +118,6 @@ class ScriptBrowserEnv(Env[dict[str, Observation], Action]):
             self.observation_handler.get_observation_space()
         )
 
-    @beartype
     def setup(self, config_file: Path | None = None) -> None:
         self.context_manager = sync_playwright()
         self.playwright = self.context_manager.__enter__()
@@ -168,23 +164,19 @@ class ScriptBrowserEnv(Env[dict[str, Observation], Action]):
                 client.send("Accessibility.enable")
             self.page.client = client  # type: ignore
 
-    @beartype
     def get_page_client(self, page: Page) -> CDPSession:
         return page.client  # type: ignore
 
-    @beartype
     def _get_obs(self) -> dict[str, Observation]:
         obs = self.observation_handler.get_observation(
             self.page, self.get_page_client(self.page)
         )
         return obs
 
-    @beartype
     def _get_obs_metadata(self) -> dict[str, ObservationMetadata]:
         metadata = self.observation_handler.get_observation_metadata()
         return metadata
 
-    @beartype
     def reset(
         self,
         *,
@@ -223,12 +215,10 @@ class ScriptBrowserEnv(Env[dict[str, Observation], Action]):
 
         return (observation, info)
 
-    @beartype
     def save_trace(self, trace_path: str | Path) -> None:
         if self.save_trace_enabled:
             self.context.tracing.stop(path=trace_path)
 
-    @beartype
     def close(self) -> None:
         if self.reset_finished:
             self.context_manager.__exit__()

--- a/browser_env/helper_functions.py
+++ b/browser_env/helper_functions.py
@@ -5,7 +5,6 @@ import re
 from pathlib import Path
 from typing import Any
 
-from beartype import beartype
 from PIL import Image
 
 from agent.prompts import *
@@ -35,7 +34,6 @@ HTML_TEMPLATE = """
 """
 
 
-@beartype
 def get_render_action(
     action: Action,
     observation_metadata: dict[str, ObservationMetadata],
@@ -63,7 +61,6 @@ def get_render_action(
     return action_str
 
 
-@beartype
 def get_action_description(
     action: Action,
     observation_metadata: dict[str, ObservationMetadata],

--- a/browser_env/processors.py
+++ b/browser_env/processors.py
@@ -1,8 +1,6 @@
 import json
 import re
-import traceback
 from collections import defaultdict
-from dataclasses import dataclass
 from typing import Any, TypedDict, Union
 
 import numpy as np
@@ -20,11 +18,16 @@ from browser_env.constants import (
 
 from .utils import (
     AccessibilityTree,
+    AccessibilityTreeNode,
     BrowserConfig,
     BrowserInfo,
+    DOMNode,
+    DOMTree,
     Observation,
     png_bytes_to_numpy,
 )
+
+IN_VIEWPORT_RATIO_THRESHOLD = 0.6
 
 
 class ObservationProcessor:
@@ -79,21 +82,19 @@ class TextObervationProcessor(ObservationProcessor):
         n = b[2] / self.viewport_size["width"]
         bounds = [[x / n for x in bound] for bound in bounds]
         tree["documents"][0]["layout"]["bounds"] = bounds
-        # add union bound placeholder
-        tree["documents"][0]["layout"]["unionBounds"] = [None for _ in bounds]
 
         # extract browser info
-        win_upper_bound = page.evaluate("window.pageYOffset")
+        win_top_bound = page.evaluate("window.pageYOffset")
         win_left_bound = page.evaluate("window.pageXOffset")
         win_width = page.evaluate("window.screen.width")
         win_height = page.evaluate("window.screen.height")
         win_right_bound = win_left_bound + win_width
-        win_lower_bound = win_upper_bound + win_height
+        win_lower_bound = win_top_bound + win_height
         device_pixel_ratio = page.evaluate("window.devicePixelRatio")
         assert device_pixel_ratio == 1.0, "devicePixelRatio is not 1.0"
 
         config: BrowserConfig = {
-            "win_upper_bound": win_upper_bound,
+            "win_top_bound": win_top_bound,
             "win_left_bound": win_left_bound,
             "win_width": win_width,
             "win_height": win_height,
@@ -109,134 +110,110 @@ class TextObervationProcessor(ObservationProcessor):
 
     @beartype
     @staticmethod
-    def partially_in_viewport(
-        bound: list[float], config: BrowserConfig
-    ) -> bool:
-        [x, y, width, height] = bound
-        elem_left_bound = x
-        elem_top_bound = y
-        elem_right_bound = x + width
-        elem_lower_bound = y + height
+    def get_bounding_client_rect(
+        client: CDPSession, backend_node_id: str
+    ) -> dict[str, Any]:
+        try:
+            remote_object = client.send(
+                "DOM.resolveNode", {"backendNodeId": int(backend_node_id)}
+            )
+            remote_object_id = remote_object["object"]["objectId"]
+            response = client.send(
+                "Runtime.callFunctionOn",
+                {
+                    "objectId": remote_object_id,
+                    "functionDeclaration": """
+                        function() {
+                            return this.getBoundingClientRect().toJSON();
+                        }
+                    """,
+                    "returnByValue": True,
+                },
+            )
+            return response
+        except Exception as e:
+            return {"result": {"subtype": "error"}}
 
-        ok = (
-            elem_left_bound < config["win_right_bound"]
-            and elem_right_bound >= config["win_left_bound"]
-            and elem_top_bound < config["win_lower_bound"]
-            and elem_lower_bound >= config["win_upper_bound"]
+    @beartype
+    @staticmethod
+    def get_element_in_viewport_ratio(
+        elem_left_bound: float,
+        elem_top_bound: float,
+        width: float,
+        height: float,
+        config: BrowserConfig,
+    ) -> float:
+        elem_right_bound = elem_left_bound + width
+        elem_lower_bound = elem_top_bound + height
+
+        win_left_bound = 0
+        win_right_bound = config["win_width"]
+        win_top_bound = 0
+        win_lower_bound = config["win_height"]
+
+        # Compute the overlap in x and y axes
+        overlap_width = max(
+            0,
+            min(elem_right_bound, win_right_bound)
+            - max(elem_left_bound, win_left_bound),
+        )
+        overlap_height = max(
+            0,
+            min(elem_lower_bound, win_lower_bound)
+            - max(elem_top_bound, win_top_bound),
         )
 
-        return ok
+        # Compute the overlap area
+        ratio = overlap_width * overlap_height / width * height
+        return ratio
 
     @beartype
-    def retrieve_viewport_info(self, info: BrowserInfo) -> None:
-        """Add viewport related information to the DOMTree
-        1. add union bound, which is a union of all the bounds of the nodes in the subtree
-        This is only used when current_viewport_only is enabled since it is quite slow
-
-        TODO[robert1003]: improve
-        """
-        tree = info["DOMTree"]
-        document = tree["documents"][0]
-        nodes = document["nodes"]
-        parent = nodes["parentIndex"]
-        node_names = nodes["nodeName"]
-
-        layout = document["layout"]
-        layout_node_cursor = layout["nodeIndex"]
-        bounds = layout["bounds"]
-
-        graph = defaultdict(lambda: [])
-        assert len(node_names) == len(parent)
-        for node_idx in range(len(node_names)):
-            parent_idx = parent[node_idx]
-            if parent_idx != -1:
-                graph[parent_idx].append(node_idx)
-
-        union_bounds: list[list[float] | None] = [None for _ in bounds]
-
-        def valid_bbox(bound: list[float] | None) -> bool:
-            if bound is None:
-                return False
-            # no width or height
-            if np.isclose(bound[2], 0):
-                return False
-            if np.isclose(bound[3], 0):
-                return False
-            return True
-
-        def add_union_bound(idx: int) -> list[float] | None:
-            if idx in layout_node_cursor:
-                cursor = layout_node_cursor.index(idx)
-                node_bound = bounds[cursor].copy()
-                tree_bounds: list[Any] = [node_bound]
-                for child_idx in graph[idx]:
-                    child_bound = add_union_bound(child_idx)
-                    tree_bounds.append(
-                        child_bound.copy() if child_bound else None
-                    )
-
-                tree_bounds = [b for b in tree_bounds if valid_bbox(b)]
-                # convert to absolute coordinates
-                for i in range(len(tree_bounds)):
-                    tree_bounds[i][2] = tree_bounds[i][0] + tree_bounds[i][2]
-                    tree_bounds[i][3] = tree_bounds[i][1] + tree_bounds[i][3]
-
-                if len(tree_bounds) == 0:
-                    assert not valid_bbox(node_bound)
-                    node_union_bound = [0.0, 0.0, 0.0, 0.0]
-                else:
-                    left_bound = min([b[0] for b in tree_bounds])
-                    top_bound = min([b[1] for b in tree_bounds])
-                    right_bound = max([b[2] for b in tree_bounds])
-                    bottom_bound = max([b[3] for b in tree_bounds])
-                    node_union_bound = [
-                        left_bound,
-                        top_bound,
-                        right_bound - left_bound,
-                        bottom_bound - top_bound,
-                    ]
-
-                # update the list
-                union_bounds[cursor] = node_union_bound
-            else:
-                node_union_bound = None
-
-            return node_union_bound
-
-        add_union_bound(0)
-        info["DOMTree"]["documents"][0]["layout"]["unionBounds"] = union_bounds
-
-    @beartype
-    def current_viewport_html(self, info: BrowserInfo) -> str:
+    def fetch_page_html(
+        self,
+        info: BrowserInfo,
+        page: Page,
+        client: CDPSession,
+        current_viewport_only: bool,
+    ) -> DOMTree:
         # adopted from [natbot](https://github.com/nat/natbot)
         tree = info["DOMTree"]
         strings = tree["strings"]
         document = tree["documents"][0]
         nodes = document["nodes"]
-        attributes = nodes["attributes"]
-        node_value = nodes["nodeValue"]
-        parent = nodes["parentIndex"]
-        node_names = nodes["nodeName"]
 
-        layout = document["layout"]
-        layout_node_cursor = layout["nodeIndex"]
-        union_bounds = layout["unionBounds"]
+        # make a dom tree that is easier to navigate
+        dom_tree: DOMTree = []
+        graph = defaultdict(list)
+        todo_nodes = {}
+        for node_idx in range(len(nodes["nodeName"])):
+            cur_node: DOMNode = {
+                "nodeId": "",
+                "nodeType": "",
+                "nodeName": "",
+                "nodeValue": "",
+                "attributes": "",
+                "backendNodeId": "",
+                "parentId": "",
+                "childIds": [],
+                "cursor": 0,
+                "union_bound": None,
+            }
 
-        graph = defaultdict(lambda: [])
-        for node_idx in range(len(node_names)):
-            parent_idx = parent[node_idx]
-            if parent_idx != -1:
-                graph[parent_idx].append(node_idx)
+            node_type_idx = nodes["nodeType"][node_idx]
+            node_type = "generic"
+            if node_type_idx >= 0 and node_type_idx < len(strings):
+                node_type = strings[node_type_idx]
 
-        def dfs(idx: int) -> str:
-            node_name = strings[node_names[idx]].lower().strip()
-            can_skip = "#" in node_name or "::" in node_name
+            node_name = strings[nodes["nodeName"][node_idx]]
 
-            inner_text = ""
-            node_value_idx = node_value[idx]
+            node_value_idx = nodes["nodeValue"][node_idx]
+            node_value = ""
             if node_value_idx >= 0 and node_value_idx < len(strings):
-                inner_text = " ".join(strings[node_value_idx].split())
-            node_attributes = [strings[i] for i in attributes[idx]]
+                node_value = " ".join(strings[node_value_idx].split())
+
+            node_attributes = [
+                strings[i] for i in nodes["attributes"][node_idx]
+            ]
             node_attributes_str = ""
             for i in range(0, len(node_attributes), 2):
                 a = node_attributes[i]
@@ -245,36 +222,157 @@ class TextObervationProcessor(ObservationProcessor):
                 node_attributes_str += f'{a}="{b}" '
             node_attributes_str = node_attributes_str.strip()
 
-            html = ""
-            if not can_skip:
-                html += f"<{node_name}"
-                if {node_attributes_str}:
-                    html += f" {node_attributes_str}"
-                html += f">{inner_text}"
+            cur_node["nodeId"] = str(node_idx)
+            cur_node["nodeType"] = node_type
+            cur_node["nodeName"] = node_name
+            cur_node["nodeValue"] = node_value
+            cur_node["attributes"] = node_attributes_str
+            cur_node["backendNodeId"] = str(nodes["backendNodeId"][node_idx])
+            cur_node["parentId"] = str(nodes["parentIndex"][node_idx])
+
+            if cur_node["parentId"] != "-1":
+                graph[cur_node["parentId"]].append(str(cur_node["nodeId"]))
+
+            # get the bound
+            if cur_node["parentId"] == "-1":
+                cur_node["union_bound"] = [0.0, 0.0, 10.0, 10.0]
+            elif cur_node["nodeName"] == "#text":
+                todo_nodes[node_idx] = int(cur_node["parentId"])
             else:
-                html += f"{inner_text}"
+                response = self.get_bounding_client_rect(
+                    client, cur_node["backendNodeId"]
+                )
+                if response.get("result", {}).get("subtype", "") == "error":
+                    cur_node["union_bound"] = None
+                else:
+                    x = response["result"]["value"]["x"]
+                    y = response["result"]["value"]["y"]
+                    width = response["result"]["value"]["width"]
+                    height = response["result"]["value"]["height"]
+                    cur_node["union_bound"] = [x, y, width, height]
 
-            for child_idx in graph[idx]:
-                if child_idx in layout_node_cursor:
-                    cursor = layout_node_cursor.index(child_idx)
-                    union_bound = union_bounds[cursor]
-                    if not self.partially_in_viewport(
-                        union_bound, info["config"]
-                    ):
-                        continue
-                    html += dfs(child_idx)
+            dom_tree.append(cur_node)
 
-            if not can_skip:
-                html += f"</{node_name}>"
+        # update the nodes whose bounds are their parents
+        for cursor, parent_cursor in todo_nodes.items():
+            dom_tree[cursor]["union_bound"] = dom_tree[parent_cursor][
+                "union_bound"
+            ]
 
-            return html
+        # add parent children index to the node
+        for parent_id, child_ids in graph.items():
+            dom_tree[int(parent_id)]["childIds"] = child_ids
 
-        html = dfs(0)
-        return html
+        # remove the nodes that are not in the current viewport
+        if current_viewport_only:
+
+            def remove_node_in_graph(node: DOMNode) -> None:
+                # update the node information in the accessibility tree
+                node_id = node["nodeId"]
+                parent_id = node["parentId"]
+                child_ids = node["childIds"]
+
+                # update the children of the parent node
+                assert dom_tree[int(parent_id)]["parentId"] != "[REMOVED]"
+                # remove the nodeid from parent
+                index = dom_tree[int(parent_id)]["childIds"].index(node_id)
+                dom_tree[int(parent_id)]["childIds"].pop(index)
+
+                # Insert children_nodeids in the same location
+                for child_id in child_ids:
+                    dom_tree[int(parent_id)]["childIds"].insert(
+                        index, child_id
+                    )
+                    index += 1
+
+                # update children node's parent
+                for child_id in child_ids:
+                    dom_tree[int(child_id)]["parentId"] = parent_id
+                # mark as removed
+                dom_tree[int(node_id)]["parentId"] = "[REMOVED]"
+
+            config = info["config"]
+            for cursor, node in enumerate(dom_tree):
+                if not node["union_bound"]:
+                    remove_node_in_graph(node)
+                    continue
+
+                [x, y, width, height] = node["union_bound"]
+
+                # invisible node
+                if width == 0.0 or height == 0.0:
+                    remove_node_in_graph(node)
+                    continue
+
+                in_viewport_ratio = self.get_element_in_viewport_ratio(
+                    elem_left_bound=float(x),
+                    elem_top_bound=float(y),
+                    width=float(width),
+                    height=float(height),
+                    config=config,
+                )
+
+                if in_viewport_ratio < IN_VIEWPORT_RATIO_THRESHOLD:
+                    remove_node_in_graph(node)
+
+            dom_tree = [
+                node
+                for node in dom_tree
+                if node.get("parentId", "-1") != "[REMOVED]"
+            ]
+
+        return dom_tree
+
+    @beartype
+    @staticmethod
+    def parse_html(dom_tree: DOMTree) -> tuple[str, dict[str, Any]]:
+        """Parse the html tree into a string text"""
+
+        obs_nodes_info = {}
+        nodeid_to_cursor = {
+            node["nodeId"]: idx for idx, node in enumerate(dom_tree)
+        }
+
+        def dfs(node_cursor: int, depth: int) -> str:
+            tree_str = ""
+            node = dom_tree[node_cursor]
+            indent = "\t" * depth
+            valid_node = True
+            try:
+                node_str = f"[{node_cursor}] <{node['nodeName']}"
+                if node["attributes"]:
+                    node_str += f" {node['attributes']}"
+                node_str += f"> {node['nodeValue']}"
+                valid_node = bool(node["attributes"] or node["nodeValue"])
+
+                if valid_node:
+                    obs_nodes_info[str(node_cursor)] = {
+                        "backend_id": node["backendNodeId"],
+                        "union_bound": node["union_bound"],
+                        "text": node_str,
+                    }
+                    tree_str += f"{indent}{node_str}\n"
+
+            except Exception as e:
+                valid_node = False
+
+            for child_ids in node["childIds"]:
+                child_cursor = nodeid_to_cursor[child_ids]
+                child_depth = depth + 1 if valid_node else depth
+                child_str = dfs(child_cursor, child_depth)
+                tree_str += child_str
+
+            return tree_str
+
+        html = dfs(0, 0)
+        return html, obs_nodes_info
 
     @beartype
     def fetch_page_accessibility_tree(
-        self, info: BrowserInfo, client: CDPSession
+        self,
+        info: BrowserInfo,
+        client: CDPSession,
+        current_viewport_only: bool,
     ) -> AccessibilityTree:
         accessibility_tree: AccessibilityTree = client.send(
             "Accessibility.getFullAXTree", {}
@@ -289,117 +387,105 @@ class TextObervationProcessor(ObservationProcessor):
                 seen_ids.add(node["nodeId"])
         accessibility_tree = _accessibility_tree
 
-        # add the bounding box of each node
-        tree = info["DOMTree"]
-        document = tree["documents"][0]
-        nodes = document["nodes"]
-        backend_node_id = nodes["backendNodeId"]
-        node_names = nodes["nodeName"]
-
-        layout = document["layout"]
-        layout_node_cursor = layout["nodeIndex"]
-        bounds = layout["bounds"]
-        union_bounds = layout["unionBounds"]
-        offsetrect_bounds = layout["offsetRects"]
-        backend_id_to_bound = {}
-
-        # get the mapping between backend node id and bounding box
-        for idx in range(len(node_names)):
-            if idx not in layout_node_cursor:
+        todo_nodes = {}
+        nodeid_to_cursor = {}
+        for cursor, node in enumerate(accessibility_tree):
+            nodeid_to_cursor[node["nodeId"]] = cursor
+            # usually because the node is not visible etc
+            if "backendDOMNodeId" not in node:
+                node["union_bound"] = None
                 continue
-            cursor = layout_node_cursor.index(idx)
-            node_bound = bounds[cursor]
-            node_union_bound = union_bounds[cursor]
-            node_offsetrect_bound = offsetrect_bounds[cursor]
-            node_backend_id = backend_node_id[idx]
-            backend_id_to_bound[node_backend_id] = [
-                node_bound,
-                node_union_bound,
-                node_offsetrect_bound,
+            backend_node_id = str(node["backendDOMNodeId"])
+            if node["role"]["value"] == "RootWebArea":
+                # always inside the viewport
+                node["union_bound"] = [0.0, 0.0, 10.0, 10.0]
+            elif node["role"]["value"] == "StaticText":
+                todo_nodes[cursor] = node["parentId"]
+            else:
+                response = self.get_bounding_client_rect(
+                    client, backend_node_id
+                )
+                if response.get("result", {}).get("subtype", "") == "error":
+                    node["union_bound"] = None
+                else:
+                    x = response["result"]["value"]["x"]
+                    y = response["result"]["value"]["y"]
+                    width = response["result"]["value"]["width"]
+                    height = response["result"]["value"]["height"]
+                    node["union_bound"] = [x, y, width, height]
+        # update the nodes whose bounds are their parents
+        for cursor, parent_id in todo_nodes.items():
+            parent_cursor = nodeid_to_cursor[parent_id]
+            accessibility_tree[cursor]["union_bound"] = accessibility_tree[
+                parent_cursor
+            ]["union_bound"]
+
+        # filter nodes that are not in the current viewport
+        if current_viewport_only:
+
+            def remove_node_in_graph(node: AccessibilityTreeNode) -> None:
+                # update the node information in the accessibility tree
+                nodeid = node["nodeId"]
+                node_cursor = nodeid_to_cursor[nodeid]
+                parent_nodeid = node["parentId"]
+                children_nodeids = node["childIds"]
+                parent_cursor = nodeid_to_cursor[parent_nodeid]
+                # update the children of the parent node
+                assert (
+                    accessibility_tree[parent_cursor].get("parentId", "Root")
+                    is not None
+                )
+                # remove the nodeid from parent's childIds
+                index = accessibility_tree[parent_cursor]["childIds"].index(
+                    nodeid
+                )
+                accessibility_tree[parent_cursor]["childIds"].pop(index)
+                # Insert children_nodeids in the same location
+                for child_nodeid in children_nodeids:
+                    accessibility_tree[parent_cursor]["childIds"].insert(
+                        index, child_nodeid
+                    )
+                    index += 1
+                # update children node's parent
+                for child_nodeid in children_nodeids:
+                    child_cursor = nodeid_to_cursor[child_nodeid]
+                    accessibility_tree[child_cursor][
+                        "parentId"
+                    ] = parent_nodeid
+                # mark as removed
+                accessibility_tree[node_cursor]["parentId"] = "[REMOVED]"
+
+            config = info["config"]
+            for node in accessibility_tree:
+                if not node["union_bound"]:
+                    remove_node_in_graph(node)
+                    continue
+
+                [x, y, width, height] = node["union_bound"]
+
+                # invisible node
+                if width == 0 or height == 0:
+                    remove_node_in_graph(node)
+                    continue
+
+                in_viewport_ratio = self.get_element_in_viewport_ratio(
+                    elem_left_bound=float(x),
+                    elem_top_bound=float(y),
+                    width=float(width),
+                    height=float(height),
+                    config=config,
+                )
+
+                if in_viewport_ratio < IN_VIEWPORT_RATIO_THRESHOLD:
+                    remove_node_in_graph(node)
+
+            accessibility_tree = [
+                node
+                for node in accessibility_tree
+                if node.get("parentId", "Root") != "[REMOVED]"
             ]
 
-        parent_graph: dict[str, str] = {}
-        refine_node_ids: list[str] = []
-        for node in accessibility_tree:
-            if "parentId" in node:
-                parent_graph[node["nodeId"]] = node["parentId"]
-            if "backendDOMNodeId" not in node:
-                node["bound"] = None
-                node["union_bound"] = None
-                node["offsetrect_bound"] = None
-            elif node["backendDOMNodeId"] not in backend_id_to_bound:
-                refine_node_ids.append(node["nodeId"])
-            else:
-                node["bound"] = backend_id_to_bound[node["backendDOMNodeId"]][
-                    0
-                ]
-                node["union_bound"] = backend_id_to_bound[
-                    node["backendDOMNodeId"]
-                ][1]
-                node["offsetrect_bound"] = backend_id_to_bound[
-                    node["backendDOMNodeId"]
-                ][2]
-
-        # refine the bounding box for nodes which only appear in the accessibility tree
-        node_ids = [node["nodeId"] for node in accessibility_tree]
-        for refine_node_id in refine_node_ids:
-            child_id = refine_node_id
-            parent_idx: None | int = None
-            while child_id in parent_graph:
-                parent_id = parent_graph[child_id]
-                parent_idx = node_ids.index(parent_id)
-                child_id = parent_id
-                if accessibility_tree[parent_idx]["union_bound"] is not None:
-                    break
-
-            refine_node_idx = node_ids.index(refine_node_id)
-
-            if parent_idx is not None:
-                accessibility_tree[refine_node_idx][
-                    "bound"
-                ] = accessibility_tree[parent_idx]["bound"]
-                accessibility_tree[refine_node_idx][
-                    "union_bound"
-                ] = accessibility_tree[parent_idx]["union_bound"]
-                accessibility_tree[refine_node_idx][
-                    "offsetrect_bound"
-                ] = accessibility_tree[parent_idx]["offsetrect_bound"]
-            else:
-                accessibility_tree[refine_node_idx]["bound"] = None
-                accessibility_tree[refine_node_idx]["union_bound"] = None
-                accessibility_tree[refine_node_idx]["offsetrect_bound"] = None
-
         return accessibility_tree
-
-    @beartype
-    def current_viewport_accessibility_tree(
-        self,
-        info: BrowserInfo,
-        accessibility_tree: AccessibilityTree,
-    ) -> AccessibilityTree:
-        config = info["config"]
-        subtree = []
-        for node in accessibility_tree:
-            if not node["union_bound"]:
-                continue
-
-            [x, y, width, height] = node["union_bound"]
-            elem_left_bound = x
-            elem_top_bound = y
-            elem_right_bound = x + width
-            elem_lower_bound = y + height
-
-            ok = (
-                elem_left_bound < config["win_right_bound"]
-                and elem_right_bound >= config["win_left_bound"]
-                and elem_top_bound < config["win_lower_bound"]
-                and elem_lower_bound >= config["win_upper_bound"]
-            )
-
-            if ok:
-                subtree.append(node)
-
-        return subtree
 
     @beartype
     @staticmethod
@@ -464,9 +550,7 @@ class TextObervationProcessor(ObservationProcessor):
                     tree_str += f"{indent}{node_str}"
                     obs_nodes_info[obs_node_id] = {
                         "backend_id": node["backendDOMNodeId"],
-                        "bound": node["bound"],
                         "union_bound": node["union_bound"],
-                        "offsetrect_bound": node["offsetrect_bound"],
                         "text": node_str,
                     }
 
@@ -540,29 +624,30 @@ class TextObervationProcessor(ObservationProcessor):
             page.wait_for_load_state("load", timeout=500)
             browser_info = self.fetch_browser_info(page, client)
 
-        if self.current_viewport_only:
-            self.retrieve_viewport_info(browser_info)
-
         if self.observation_type == "html":
-            if self.current_viewport_only:
-                html = self.current_viewport_html(browser_info)
-                content = html
-            else:
-                content = page.content()
+            dom_tree = self.fetch_page_html(
+                browser_info,
+                page,
+                client,
+                current_viewport_only=self.current_viewport_only,
+            )
+            content, obs_nodes_info = self.parse_html(dom_tree)
+            self.obs_nodes_info = obs_nodes_info
+            self.meta_data["obs_nodes_info"] = obs_nodes_info
+
         elif self.observation_type == "accessibility_tree":
             accessibility_tree = self.fetch_page_accessibility_tree(
-                browser_info, client
+                browser_info,
+                client,
+                current_viewport_only=self.current_viewport_only,
             )
-            if self.current_viewport_only:
-                accessibility_tree = self.current_viewport_accessibility_tree(
-                    browser_info, accessibility_tree
-                )
             content, obs_nodes_info = self.parse_accessibility_tree(
                 accessibility_tree
             )
             content = self.clean_accesibility_tree(content)
             self.obs_nodes_info = obs_nodes_info
             self.meta_data["obs_nodes_info"] = obs_nodes_info
+
         else:
             raise ValueError(
                 f"Invalid observatrion type: {self.observation_type}"
@@ -575,15 +660,10 @@ class TextObervationProcessor(ObservationProcessor):
     @beartype
     def get_element_center(self, element_id: str) -> tuple[float, float]:
         node_info = self.obs_nodes_info[element_id]
-        node_bound = node_info["bound"]
+        node_bound = node_info["union_bound"]
         x, y, width, height = node_bound
-        browser_config = self.browser_config
-        b_x, b_y = (
-            browser_config["win_left_bound"],
-            browser_config["win_upper_bound"],
-        )
-        center_x = (x - b_x) + width / 2
-        center_y = (y - b_y) + height / 2
+        center_x = x + width / 2
+        center_y = y + height / 2
         return (
             center_x / self.viewport_size["width"],
             center_y / self.viewport_size["height"],

--- a/browser_env/processors.py
+++ b/browser_env/processors.py
@@ -5,7 +5,6 @@ from typing import Any, TypedDict, Union
 
 import numpy as np
 import numpy.typing as npt
-from beartype import beartype
 from gymnasium import spaces
 from playwright.sync_api import CDPSession, Page, ViewportSize
 
@@ -60,7 +59,6 @@ class TextObervationProcessor(ObservationProcessor):
             create_empty_metadata()
         )  # use the store meta data of this observation type
 
-    @beartype
     def fetch_browser_info(
         self,
         page: Page,
@@ -108,7 +106,6 @@ class TextObervationProcessor(ObservationProcessor):
 
         return info
 
-    @beartype
     @staticmethod
     def get_bounding_client_rect(
         client: CDPSession, backend_node_id: str
@@ -134,7 +131,6 @@ class TextObervationProcessor(ObservationProcessor):
         except Exception as e:
             return {"result": {"subtype": "error"}}
 
-    @beartype
     @staticmethod
     def get_element_in_viewport_ratio(
         elem_left_bound: float,
@@ -167,7 +163,6 @@ class TextObervationProcessor(ObservationProcessor):
         ratio = overlap_width * overlap_height / width * height
         return ratio
 
-    @beartype
     def fetch_page_html(
         self,
         info: BrowserInfo,
@@ -323,7 +318,6 @@ class TextObervationProcessor(ObservationProcessor):
 
         return dom_tree
 
-    @beartype
     @staticmethod
     def parse_html(dom_tree: DOMTree) -> tuple[str, dict[str, Any]]:
         """Parse the html tree into a string text"""
@@ -367,7 +361,6 @@ class TextObervationProcessor(ObservationProcessor):
         html = dfs(0, 0)
         return html, obs_nodes_info
 
-    @beartype
     def fetch_page_accessibility_tree(
         self,
         info: BrowserInfo,
@@ -487,7 +480,6 @@ class TextObervationProcessor(ObservationProcessor):
 
         return accessibility_tree
 
-    @beartype
     @staticmethod
     def parse_accessibility_tree(
         accessibility_tree: AccessibilityTree,
@@ -575,7 +567,6 @@ class TextObervationProcessor(ObservationProcessor):
         tree_str = dfs(0, accessibility_tree[0]["nodeId"], 0)
         return tree_str, obs_nodes_info
 
-    @beartype
     @staticmethod
     def clean_accesibility_tree(tree_str: str) -> str:
         """further clean accesibility tree"""
@@ -598,7 +589,6 @@ class TextObervationProcessor(ObservationProcessor):
 
         return "\n".join(clean_lines)
 
-    @beartype
     def process(self, page: Page, client: CDPSession) -> str:
         # get the tab info
         open_tabs = page.context.pages
@@ -657,7 +647,6 @@ class TextObervationProcessor(ObservationProcessor):
         content = f"{tab_title_str}\n\n{content}"
         return content
 
-    @beartype
     def get_element_center(self, element_id: str) -> tuple[float, float]:
         node_info = self.obs_nodes_info[element_id]
         node_bound = node_info["union_bound"]
@@ -705,7 +694,6 @@ class ObservationHandler:
         )
         self.viewport_size = viewport_size
 
-    @beartype
     def get_observation_space(self) -> spaces.Dict:
         text_space = spaces.Text(
             min_length=0,
@@ -729,7 +717,6 @@ class ObservationHandler:
 
         return spaces.Dict({"text": text_space, "image": image_space})
 
-    @beartype
     def get_observation(
         self, page: Page, client: CDPSession
     ) -> dict[str, Observation]:
@@ -737,7 +724,6 @@ class ObservationHandler:
         image_obs = self.image_processor.process(page, client)
         return {"text": text_obs, "image": image_obs}
 
-    @beartype
     def get_observation_metadata(self) -> dict[str, ObservationMetadata]:
         return {
             "text": self.text_processor.meta_data,

--- a/browser_env/utils.py
+++ b/browser_env/utils.py
@@ -35,15 +35,28 @@ class AccessibilityTreeNode(TypedDict):
     properties: list[dict[str, Any]]
     childIds: list[str]
     parentId: str
-    backendDOMNodeId: int
+    backendDOMNodeId: str
     frameId: str
     bound: list[float] | None
     union_bound: list[float] | None
     offsetrect_bound: list[float] | None
 
 
+class DOMNode(TypedDict):
+    nodeId: str
+    nodeType: str
+    nodeName: str
+    nodeValue: str
+    attributes: str
+    backendNodeId: str
+    parentId: str
+    childIds: list[str]
+    cursor: int
+    union_bound: list[float] | None
+
+
 class BrowserConfig(TypedDict):
-    win_upper_bound: float
+    win_top_bound: float
     win_left_bound: float
     win_width: float
     win_height: float
@@ -58,6 +71,7 @@ class BrowserInfo(TypedDict):
 
 
 AccessibilityTree = list[AccessibilityTreeNode]
+DOMTree = list[DOMNode]
 
 
 Observation = str | npt.NDArray[np.uint8]

--- a/browser_env/utils.py
+++ b/browser_env/utils.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, TypedDict, Union
 
 import numpy as np
 import numpy.typing as npt
-from beartype import beartype
 from PIL import Image
 
 
@@ -14,7 +13,6 @@ class DetachedPage:
     content: str  # html
 
 
-@beartype
 def png_bytes_to_numpy(png: bytes) -> npt.NDArray[np.uint8]:
     """Convert png bytes to numpy array
 

--- a/evaluation_harness/evaluators.py
+++ b/evaluation_harness/evaluators.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Tuple, Union
 
 import evaluate  # type: ignore[import]
+from beartype import beartype
 from playwright.sync_api import CDPSession, Page
 
 from browser_env.actions import Action
@@ -28,6 +29,7 @@ class Evaluator(object):
     def __init__(self, eval_tag: str = "") -> None:
         self.eval_tag = eval_tag
 
+    @beartype
     def __call__(
         self,
         trajectory: Trajectory,
@@ -65,6 +67,7 @@ class Evaluator(object):
 class StringExactEvaluator(Evaluator):
     """Check whether the answer is exactly the same as one of the reference answers"""
 
+    @beartype
     def __call__(
         self,
         trajectory: Trajectory,
@@ -98,6 +101,7 @@ class StringEvaluator(Evaluator):
     fuzzy match: the answer is similar to the reference answer, using LLM judge
     """
 
+    @beartype
     def __call__(
         self,
         trajectory: Trajectory,
@@ -142,6 +146,7 @@ class StringEvaluator(Evaluator):
 class StringSoftEvaluator(Evaluator):
     """Use text generation metrics such as BLEU, ROUGE, etc. to evaluate the answer"""
 
+    @beartype
     def __call__(
         self,
         trajectory: Trajectory,
@@ -164,6 +169,7 @@ class StringSoftEvaluator(Evaluator):
 class URLExactEvaluator(Evaluator):
     """Check whether the URL is exactly the same as of the reference URLs"""
 
+    @beartype
     def __call__(
         self,
         trajectory: Trajectory,
@@ -201,6 +207,7 @@ class URLExactEvaluator(Evaluator):
 class HTMLContentExactEvaluator(Evaluator):
     """Check whether the contents appear in the page"""
 
+    @beartype
     def __call__(
         self,
         trajectory: Trajectory,
@@ -341,6 +348,7 @@ class EvaluatorComb:
     def __init__(self, evaluators: list[Evaluator]) -> None:
         self.evaluators = evaluators
 
+    @beartype
     def __call__(
         self,
         trajectory: Trajectory,
@@ -357,6 +365,7 @@ class EvaluatorComb:
         return score
 
 
+@beartype
 def evaluator_router(config_file: Path | str) -> EvaluatorComb:
     """Router to get the evaluator class"""
     with open(config_file, "r") as f:

--- a/evaluation_harness/evaluators.py
+++ b/evaluation_harness/evaluators.py
@@ -8,8 +8,6 @@ from pathlib import Path
 from typing import Any, Tuple, Union
 
 import evaluate  # type: ignore[import]
-from beartype import beartype
-from beartype.door import is_bearable
 from playwright.sync_api import CDPSession, Page
 
 from browser_env.actions import Action
@@ -26,7 +24,6 @@ from evaluation_harness.helper_functions import (
 Trajectory = list[Union[Action, StateInfo]]
 
 
-@beartype
 class Evaluator(object):
     def __init__(self, eval_tag: str = "") -> None:
         self.eval_tag = eval_tag
@@ -43,7 +40,7 @@ class Evaluator(object):
     @staticmethod
     def get_last_action(trajectory: Trajectory) -> Action:
         try:
-            is_bearable(trajectory[-1], Action)
+            # is_bearable(trajectory[-1], Action)
             last_action = trajectory[-1]
         except Exception:
             raise ValueError(
@@ -55,7 +52,7 @@ class Evaluator(object):
     @staticmethod
     def get_last_state(trajectory: Trajectory) -> StateInfo:
         try:
-            is_bearable(trajectory[-2], StateInfo)
+            # is_bearable(trajectory[-2], StateInfo)
             last_state = trajectory[-2]
         except Exception:
             raise ValueError(
@@ -65,7 +62,6 @@ class Evaluator(object):
         return last_state  # type: ignore[return-value]
 
 
-@beartype
 class StringExactEvaluator(Evaluator):
     """Check whether the answer is exactly the same as one of the reference answers"""
 
@@ -95,7 +91,6 @@ class StringExactEvaluator(Evaluator):
             return 0.0
 
 
-@beartype
 class StringEvaluator(Evaluator):
     """Check whether the answer is correct with:
     exact match: the answer is exactly the same as the reference answer
@@ -144,7 +139,6 @@ class StringEvaluator(Evaluator):
         return score
 
 
-@beartype
 class StringSoftEvaluator(Evaluator):
     """Use text generation metrics such as BLEU, ROUGE, etc. to evaluate the answer"""
 
@@ -167,7 +161,6 @@ class StringSoftEvaluator(Evaluator):
         return float(rouge["rouge1"])
 
 
-@beartype
 class URLExactEvaluator(Evaluator):
     """Check whether the URL is exactly the same as of the reference URLs"""
 
@@ -205,7 +198,6 @@ class URLExactEvaluator(Evaluator):
             raise ValueError(f"Unknown matching rule: {matching_rule}")
 
 
-@beartype
 class HTMLContentExactEvaluator(Evaluator):
     """Check whether the contents appear in the page"""
 
@@ -286,7 +278,6 @@ class HTMLContentExactEvaluator(Evaluator):
 ######
 
 
-@beartype
 class EvaluatorPartial(Evaluator):
     def __init__(self) -> None:
         raise NotImplementedError
@@ -301,7 +292,6 @@ class EvaluatorPartial(Evaluator):
         raise NotImplementedError
 
 
-@beartype
 class URLSoftEvaluator(EvaluatorPartial):
     """Parse the URL and compare the domain and parameters"""
 
@@ -367,7 +357,6 @@ class EvaluatorComb:
         return score
 
 
-@beartype
 def evaluator_router(config_file: Path | str) -> EvaluatorComb:
     """Router to get the evaluator class"""
     with open(config_file, "r") as f:

--- a/evaluation_harness/helper_functions.py
+++ b/evaluation_harness/helper_functions.py
@@ -4,7 +4,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 import requests
-from beartype import beartype
 from playwright.sync_api import CDPSession, Page
 
 from browser_env.env_config import (
@@ -21,7 +20,6 @@ from llms.providers.openai_utils import (
 )
 
 
-@beartype
 def shopping_get_auth_token() -> str:
     response = requests.post(
         url=f"{SHOPPING}/rest/default/V1/integration/admin/token",
@@ -37,7 +35,6 @@ def shopping_get_auth_token() -> str:
     return token
 
 
-@beartype
 def shopping_get_latest_order_url() -> str:
     """Get the latest order url from the shopping website."""
 
@@ -62,7 +59,6 @@ def shopping_get_latest_order_url() -> str:
     return order_url
 
 
-@beartype
 def shopping_get_sku_latest_review_author(sku: str) -> str:
     """Get the latest review for shopping admin."""
     header = {
@@ -80,7 +76,6 @@ def shopping_get_sku_latest_review_author(sku: str) -> str:
     return author
 
 
-@beartype
 def shopping_get_sku_latest_review_rating(sku: str) -> str:
     """Get the latest review for shopping admin."""
     header = {
@@ -99,7 +94,6 @@ def shopping_get_sku_latest_review_rating(sku: str) -> str:
     return rating
 
 
-@beartype
 def reddit_get_post_url(url: str) -> str:
     """Get the post url"""
     # Url is http://domain/f/subreddit/post_id/...
@@ -118,7 +112,6 @@ def reddit_get_post_url(url: str) -> str:
     return post_url
 
 
-@beartype
 def gitlab_get_project_memeber_role(page: Page, account_name: str) -> str:
     # get the account index
     try:
@@ -150,7 +143,6 @@ def gitlab_get_project_memeber_role(page: Page, account_name: str) -> str:
     return role
 
 
-@beartype
 def llm_fuzzy_match(pred: str, reference: str, question: str) -> float:
     """Check whether the prediction matches the reference with GPT-3.5"""
     messages: list[dict[str, Any]] = []

--- a/run.py
+++ b/run.py
@@ -9,7 +9,6 @@ import time
 from pathlib import Path
 
 import openai
-from beartype import beartype
 
 from agent import (
     Agent,
@@ -144,7 +143,6 @@ def config() -> argparse.Namespace:
     return args
 
 
-@beartype
 def early_stop(
     trajectory: Trajectory, max_steps: int, thresholds: dict[str, int]
 ) -> tuple[bool, str]:
@@ -201,7 +199,6 @@ def early_stop(
     return False, ""
 
 
-@beartype
 def test(
     args: argparse.Namespace,
     agent: Agent | PromptAgent | TeacherForcingAgent,
@@ -369,7 +366,6 @@ def get_unfinished(config_files: list[str], result_dir: str) -> list[str]:
     return unfinished_configs
 
 
-@beartype
 def dump_config(args: argparse.Namespace) -> None:
     config_file = Path(args.result_dir) / "config.json"
     if not config_file.exists():

--- a/scripts/collect_obs.py
+++ b/scripts/collect_obs.py
@@ -6,7 +6,6 @@ import time
 from typing import Dict, Optional, Tuple, Type, Union, cast
 
 import pytest
-from beartype import beartype
 from playwright.sync_api import Page, expect
 
 from browser_env import (
@@ -21,13 +20,11 @@ from browser_env.env_config import *
 HEADLESS = False
 
 
-@beartype
 def gen_tmp_storage_state() -> None:
     with open(f"scripts/tmp_storage_state.json", "w") as f:
         json.dump({"storage_state": ".auth/gitlab_state.json"}, f)
 
 
-@beartype
 def get_observation(
     observation_type: str, current_viewport_only: bool
 ) -> None:

--- a/scripts/collect_obs.py
+++ b/scripts/collect_obs.py
@@ -24,7 +24,7 @@ HEADLESS = False
 @beartype
 def gen_tmp_storage_state() -> None:
     with open(f"scripts/tmp_storage_state.json", "w") as f:
-        json.dump({"storage_state": ".auth/reddit_state.json"}, f)
+        json.dump({"storage_state": ".auth/gitlab_state.json"}, f)
 
 
 @beartype
@@ -37,7 +37,8 @@ def get_observation(
         headless=HEADLESS,
     )
     env.reset(options={"config_file": f"scripts/tmp_storage_state.json"})
-    s = f"""page.goto("{GITLAB}")
+    s = f"""page.goto("{GITLAB}/byteblaze/a11y-syntax-highlighting")
+    page.scroll(down)
     page.scroll(down)"""
     action_seq = s.split("\n")
 

--- a/tests/test_browser_env/test_script_browser_env.py
+++ b/tests/test_browser_env/test_script_browser_env.py
@@ -134,36 +134,6 @@ def test_parallel_script_browser_env() -> None:
     vector_env.close()  # type: ignore[no-untyped-call]
 
 
-def test_is_in_viewport(script_browser_env: ScriptBrowserEnv) -> None:
-    env = script_browser_env
-    env.reset()
-    env.step(
-        create_goto_url_action("https://www.iana.org/domains/reserved"),
-    )
-    _, _, _, _, info = env.step(
-        create_focus_and_click_action(
-            element_role="link",
-            element_name="IDN",
-            nth=1,
-        ),
-    )
-    assert (
-        info["page"].url
-        == "https://www.icann.org/resources/pages/idn-2012-02-25-en"
-    )
-    env.step(
-        create_goto_url_action("https://www.iana.org/domains/reserved"),
-    )
-    _, _, _, _, info = env.step(create_keyboard_type_action(keys=["PageDown"]))
-    _, _, _, _, info = env.step(
-        create_focus_and_click_action(
-            element_role="link",
-            element_name="IDN",
-        ),
-    )
-    assert info["page"].url == "https://www.iana.org/domains/idn-tables"
-
-
 def test_focus_placeholder_and_label(
     script_browser_env: ScriptBrowserEnv,
 ) -> None:
@@ -183,7 +153,7 @@ def test_focus_placeholder_and_label(
     assert info["page"].url == "https://demo.applitools.com/app.html"
 
 
-def test_current_viewport(
+def test_html_current_viewport(
     current_viewport_script_browser_env: ScriptBrowserEnv,
 ) -> None:
     s1 = "detailed information about how mammals could be classified."
@@ -236,7 +206,6 @@ def test_accessibility_tree_viewport(
     assert (
         s1 in obs["text"] and s2 not in obs["text"] and s3 not in obs["text"]
     )
-
     obs, success, _, _, info = env.step(create_scroll_action("down"))
     assert success
     assert (

--- a/tests/test_browser_env/test_script_browser_env.py
+++ b/tests/test_browser_env/test_script_browser_env.py
@@ -5,7 +5,6 @@ import tempfile
 from typing import Callable, Dict, Optional, Tuple, Type, Union, cast
 
 import pytest
-from beartype.door import is_bearable
 from gymnasium.vector import AsyncVectorEnv
 from playwright.sync_api import Page
 
@@ -128,7 +127,7 @@ def test_parallel_script_browser_env() -> None:
             ]
         )
     )
-    assert is_bearable(info["page"].tolist(), list[DetachedPage])
+    # assert is_bearable(info["page"].tolist(), list[DetachedPage])
     assert info["page"][0].url == "https://www.rfc-editor.org/rfc/rfc2606.html"
     assert info["page"][1].url == "https://www.rfc-editor.org/rfc/rfc6761.html"
     vector_env.close()  # type: ignore[no-untyped-call]

--- a/tests/test_evaluation_harness/test_exact_evaluators.py
+++ b/tests/test_evaluation_harness/test_exact_evaluators.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from beartype import beartype
 from py import test
 
 from agent import Agent, TeacherForcingAgent
@@ -249,7 +248,6 @@ def test_html_content_url_comb_success(
     assert score == 1.0
 
 
-@beartype
 @pytest.mark.skipif(
     IN_GITHUB_ACTIONS, reason="Won't work using the demo sites"
 )
@@ -273,7 +271,6 @@ def test_func_success(
     assert score == 1.0
 
 
-@beartype
 @pytest.mark.skipif(
     IN_GITHUB_ACTIONS, reason="Won't work using the demo sites"
 )
@@ -297,7 +294,6 @@ def test_func_fail(
     assert score == 0.0
 
 
-@beartype
 def test_func_url_func_last_success(
     script_browser_env: ScriptBrowserEnv,
 ) -> None:
@@ -319,7 +315,6 @@ def test_func_url_func_last_success(
     assert score == 1.0
 
 
-@beartype
 def test_func_url_func_page_success(
     script_browser_env: ScriptBrowserEnv,
 ) -> None:

--- a/tests/test_evaluation_harness/test_helper_functions.py
+++ b/tests/test_evaluation_harness/test_helper_functions.py
@@ -2,8 +2,6 @@ import json
 import os
 from pathlib import Path
 
-from beartype import beartype
-
 from browser_env import ScriptBrowserEnv
 from browser_env.env_config import *
 from evaluation_harness.helper_functions import (


### PR DESCRIPTION
We relied on the bounding box provided by `DOMSnapshot.captureSnapshot` before. However, there are many problems with this method. Now we individually check each element by hooking it to its remote object through `DOM.resolveNode` and `getclientboundingrect`
