### PR TITLE
fix reference answer for task 301 and 302 as it requires a dict, not str

### DIFF
--- a/config_files/test.raw.json
+++ b/config_files/test.raw.json
@@ -9416,7 +9416,9 @@
       "eval_types": [
         "string_match"
       ],
-      "reference_answers": "N/A",
+      "reference_answers": {
+        "exact_match": "N/A"
+      },
       "reference_url": "",
       "program_html": [],
       "string_note": "There is no order in the processing status",
@@ -9443,7 +9445,9 @@
       "eval_types": [
         "string_match"
       ],
-      "reference_answers": "N/A",
+      "reference_answers": {
+        "exact_match": "N/A"
+      },
       "reference_url": "",
       "program_html": [],
       "string_note": "There is no order out of delivery",


### PR DESCRIPTION
in webarena/evaluation_harness/evaluators.py line 127, in class StringEvaluator, reference_answers expects a dict but task 301 and 302 gives a string. fixed it to be in line with other string match annotations