### PR TITLE
Update evaluators.py

### DIFF
--- a/evaluation_harness/evaluators.py
+++ b/evaluation_harness/evaluators.py
@@ -195,12 +195,12 @@ class URLEvaluator(Evaluator):
         matching_rule = configs["eval"].get("url_note", "GOLD in PRED")
         if matching_rule == "GOLD in PRED":
             ref_base_paths, ref_queries = parse_urls(ref_urls)
-            pred_base_paths, pred_query = parse_url(pred)
+            pred_base_path, pred_query = parse_url(pred)
 
             base_score = float(
                 any(
                     [
-                        ref_base_path in pred_base_paths
+                        ref_base_path == pred_base_path
                         for ref_base_path in ref_base_paths
                     ]
                 )


### PR DESCRIPTION
Addresses an eval bug that causes false positives.

**Bug:** Before, the URL `ec2-3-131-244-37.us-east-2.compute.amazonaws.com:7780/admin/reports/report_product/viewedasdf` would get a score of 1.0 for the reference URL `ec2-3-131-244-37.us-east-2.compute.amazonaws.com:7780/admin/reports/report_product/viewed`.

**Edit**. This commit requires the URLs to match exactly to get credit.