### PR TITLE
Wrong scroll action specification in the prompts vs. in the parsing function

### DIFF
--- a/agent/prompts/raw/p_cot_id_actree_2s.py
+++ b/agent/prompts/raw/p_cot_id_actree_2s.py
@@ -15,7 +15,7 @@ Page Operation Actions:
 `type [id] [content] [press_enter_after=0|1]`: Use this to type the content into the field with id. By default, the "Enter" key is pressed after typing unless press_enter_after is set to 0.
 `hover [id]`: Hover over an element with id.
 `press [key_comb]`:  Simulates the pressing of a key combination on the keyboard (e.g., Ctrl+v).
-`scroll [direction=down|up]`: Scroll the page up or down.
+`scroll [down|up]`: Scroll the page up or down.
 
 Tab Management Actions:
 `new_tab`: Open a new, empty browser tab.

--- a/agent/prompts/raw/p_cot_id_actree_2s_no_na.py
+++ b/agent/prompts/raw/p_cot_id_actree_2s_no_na.py
@@ -15,7 +15,7 @@ Page Operation Actions:
 `type [id] [content] [press_enter_after=0|1]`: Use this to type the content into the field with id. By default, the "Enter" key is pressed after typing unless press_enter_after is set to 0.
 `hover [id]`: Hover over an element with id.
 `press [key_comb]`:  Simulates the pressing of a key combination on the keyboard (e.g., Ctrl+v).
-`scroll [direction=down|up]`: Scroll the page up or down.
+`scroll [down|up]`: Scroll the page up or down.
 
 Tab Management Actions:
 `new_tab`: Open a new, empty browser tab.

--- a/agent/prompts/raw/p_direct_id_actree_2s.py
+++ b/agent/prompts/raw/p_direct_id_actree_2s.py
@@ -15,7 +15,7 @@ Page Operation Actions:
 `type [id] [content] [press_enter_after=0|1]`: Use this to type the content into the field with id. By default, the "Enter" key is pressed after typing unless press_enter_after is set to 0.
 `hover [id]`: Hover over an element with id.
 `press [key_comb]`:  Simulates the pressing of a key combination on the keyboard (e.g., Ctrl+v).
-`scroll [direction=down|up]`: Scroll the page up or down.
+`scroll [down|up]`: Scroll the page up or down.
 
 Tab Management Actions:
 `new_tab`: Open a new, empty browser tab.

--- a/agent/prompts/raw/p_direct_id_actree_2s_no_na.py
+++ b/agent/prompts/raw/p_direct_id_actree_2s_no_na.py
@@ -15,7 +15,7 @@ Page Operation Actions:
 `type [id] [content] [press_enter_after=0|1]`: Use this to type the content into the field with id. By default, the "Enter" key is pressed after typing unless press_enter_after is set to 0.
 `hover [id]`: Hover over an element with id.
 `press [key_comb]`:  Simulates the pressing of a key combination on the keyboard (e.g., Ctrl+v).
-`scroll [direction=down|up]`: Scroll the page up or down.
+`scroll [down|up]`: Scroll the page up or down.
 
 Tab Management Actions:
 `new_tab`: Open a new, empty browser tab.

--- a/agent/prompts/raw/p_direct_id_actree_3s_llama.py
+++ b/agent/prompts/raw/p_direct_id_actree_3s_llama.py
@@ -6,7 +6,7 @@ Page Operation Actions:
 `type [id] [content] [press_enter_after=0|1]`: Use this to type the content into the field with id. By default, the "Enter" key is pressed after typing unless press_enter_after is set to 0.
 `hover [id]`: Hover over an element with id.
 `press [key_comb]`:  Simulates the pressing of a key combination on the keyboard (e.g., Ctrl+v).
-`scroll [direction=down|up]`: Scroll the page up or down.
+`scroll [down|up]`: Scroll the page up or down.
 
 Tab Management Actions:
 `new_tab`: Open a new, empty browser tab.


### PR DESCRIPTION
Hi, I'm reporting just a small bug, the prompts all say to use "scroll [direction=up|down]" but the parsing function expects "scroll [up|down]". This way the parsing always fails for the scroll action because the model always generates "scroll [direction=up|down]".