### PR TITLE
docs(map): AWS-backed map backends via S3 + cloud-init; keep frontend server instructions unchanged

### DIFF
--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -211,13 +211,13 @@ runcmd:
   - systemctl enable --now docker
   - mkdir -p /opt/osm_dump /opt/osrm /var/lib/docker/volumes
   # Pull prebuilt data from public S3
-  - aws s3 cp s3://webarena-map-server-data/osm_tile_server.tar /root/osm_tile_server.tar
+  - aws s3 cp --no-sign-request s3://webarena-map-server-data/osm_tile_server.tar /root/osm_tile_server.tar
   - tar -C /var/lib/docker/volumes -xf /root/osm_tile_server.tar
-  - aws s3 cp s3://webarena-map-server-data/nominatim_volumes.tar /root/nominatim_volumes.tar
+  - aws s3 cp --no-sign-request s3://webarena-map-server-data/nominatim_volumes.tar /root/nominatim_volumes.tar
   - tar -C /var/lib/docker/volumes -xf /root/nominatim_volumes.tar
-  - aws s3 cp s3://webarena-map-server-data/osm_dump.tar /root/osm_dump.tar
+  - aws s3 cp --no-sign-request s3://webarena-map-server-data/osm_dump.tar /root/osm_dump.tar
   - tar -C /opt/osm_dump -xf /root/osm_dump.tar
-  - aws s3 cp s3://webarena-map-server-data/osrm_routing.tar /root/osrm_routing.tar
+  - aws s3 cp --no-sign-request s3://webarena-map-server-data/osrm_routing.tar /root/osrm_routing.tar
   - tar -C /opt/osrm -xf /root/osrm_routing.tar
   # Start containers (set restart policies)
   - docker pull overv/openstreetmap-tile-server

--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -254,11 +254,7 @@ Endpoints (after the instance boots)
 - Geocoding: http://<your-server-hostname>:8085/
 - Routing: http://<your-server-hostname>:5000 (car), :5001 (bike), :5002 (foot)
 
-Frontend configuration notes
-- Leaflet tile URL: Update `TileLayer`/`Mapnik` URL in your frontend to `http://<your-server-hostname>:8080/tile/{z}/{x}/{y}.png`.
-- openstreetmap-website settings.yml:
-  - `nominatim_url`: set to `http://<your-server-hostname>:8085/`
-  - `fossgis_osrm_url`: use OSRM endpoints above or the official defaults as needed.
+Note: The instructions here cover backend services (tiles/geocoding/routing) only. The map frontend server setup remains unchanged; see the AMI section above.
 
 Advanced/manual details (if not using cloud-init)
 - The S3 keys available are:

--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -186,7 +186,11 @@ The homepage will be available at `http://<your-server-hostname>:4399`.
 
 ### Map
 
-Recommended: AWS-based setup using S3 data bucket s3://webarena-map-server-data. This bucket contains prebuilt data for all map backends so you don't need to generate tiles or preprocess OSM data.
+Please refer to the AMI setup for the map frontend setup. For most use cases this is enough.
+
+If you wish to also set up all map backends (tile server, geocoding server, routing servers), read along and please be aware of very large downloads and disk space requirements.
+
+AWS backend setup (tile/geocoding/routing) using S3 data bucket s3://webarena-map-server-data. This bucket contains prebuilt data for the map backends so you don't need to generate tiles or preprocess OSM data.
 
 The map stack consists of:
 - Tile server: overv/openstreetmap-tile-server (serves raster tiles)


### PR DESCRIPTION
Adds AWS-based backend setup (tiles/geocoding/routing) using public S3 bucket and cloud-init. Frontend instructions unchanged.

Co-authored-by: openhands <openhands@all-hands.dev>