### PR TITLE
docs(AMI): make AMI public in us-east-2 and clarify region/visibility so users can find it

### DIFF
--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -18,11 +18,14 @@ This REAME file host the instructions for our Docker images and quick start guid
 We provide AMI which have all the websites pre-installed. You can use the AMI to start a new EC2 instance.
 
 ```
-AMI Information: find in console, EC2 - AMI Catalog
-Region: us-east-2
+AMI Information (EC2 console > AMIs). IMPORTANT: AMIs are region-scoped.
+Region: us-east-2 (Ohio)
+Visibility: Public (available to all accounts in us-east-2)
 Name: webarena-with-configurable-map-backend
 ID: ami-08a862bf98e3bd7aa
 ```
+
+Note: If you cannot find the AMI, make sure the EC2 console region is switched to us-east-2 (Ohio).
 
 1. Create a security group that allows all inbound traffic, or at minimum, create a security group with the following inbound rules:
    - SSH (port 22) from your IP


### PR DESCRIPTION
Summary
- Make the WebArena AMI public in us-east-2 (Ohio) and ensure the backing snapshot is also public so any account can launch it in that region.
- Update environment_docker/README.md to clearly document region scoping and visibility.

Changes
- AWS:
  - Set AMI ami-08a862bf98e3bd7aa launch permissions to public (Group=all) in us-east-2.
  - Set snapshot snap-07d315b778cc402cc createVolumePermission to public (Group=all).
  - Re-enabled account-level "block-new-sharing" after making the AMI public to prevent accidental future sharing.
- Docs:
  - environment_docker/README.md now includes:
    - Region: us-east-2 (Ohio)
    - Visibility: Public (available to all accounts in us-east-2)
    - A note reminding users to switch their EC2 console region to us-east-2 if they cannot find the AMI.

Why
Users reported they could not find the AMI. The image existed only in us-east-2 and was private to the owner account. Making it public and documenting the region resolves the issue.

Testing/Verification
- Verified via AWS API:
  - AMI Public: True, LaunchPermissions: [{Group: all}]
  - Snapshot permissions: [{Group: all}]
- Confirmed the AMI is discoverable in us-east-2. Other regions will not show this AMI ID (region-scoped).

Notes
- The AMI is only published in us-east-2. If regional availability is desired elsewhere, we can copy the AMI to additional regions and apply the same visibility settings.

Checklist
- [x] Update docs to clarify region and visibility
- [x] Ensure AMI and backing snapshot are publicly launchable in us-east-2
- [x] Keep account-level block-new-sharing enabled post-change

Fixes https://github.com/web-arena-x/webarena/issues/225

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e3457d5289b84773b0af5da9f06306f8)