### PR TITLE
Fix Postgres running as root error

### DIFF
--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -85,7 +85,7 @@ docker exec gitlab gitlab-ctl reconfigure
 **If GitLab shows 502 errors**, run:
 ```bash
 docker exec gitlab rm -f /var/opt/gitlab/postgresql/data/postmaster.pid
-docker exec gitlab /opt/gitlab/embedded/bin/pg_resetwal -f /var/opt/gitlab/postgresql/data
+docker exec -u gitlab-psql gitlab /opt/gitlab/embedded/bin/pg_resetwal -f /var/opt/gitlab/postgresql/data
 docker exec gitlab gitlab-ctl restart
 ```
 


### PR DESCRIPTION
Fix the "pg_resetwal: error: cannot be executed by "root"
pg_resetwal: You must run pg_resetwal as the PostgreSQL superuser." error when running `docker exec gitlab /opt/gitlab/embedded/bin/pg_resetwal -f /var/opt/gitlab/postgresql/data`