### PR TITLE
Replace deprecated judge model

### DIFF
--- a/evaluation_harness/helper_functions.py
+++ b/evaluation_harness/helper_functions.py
@@ -159,7 +159,7 @@ def llm_fuzzy_match(pred: str, reference: str, question: str) -> float:
     ]
 
     response = generate_from_openai_chat_completion(
-        model="gpt-4-1106-preview",
+        model="gpt-5",
         messages=messages,
         temperature=0,
         max_tokens=768,
@@ -194,7 +194,7 @@ def llm_ua_match(pred: str, reference: str, question: str) -> float:
     ]
 
     response = generate_from_openai_chat_completion(
-        model="gpt-4-1106-preview",
+        model="gpt-5",
         messages=messages,
         temperature=0,
         max_tokens=768,


### PR DESCRIPTION
gpt-4-1106-preview is no longer available via API, so we get

```
invalid_request_error: The model `gpt-4-1106-preview` does not exist or you do not have access to it
```

OpenAI recommends gpt-5 as a replacement:
https://developers.openai.com/api/docs/deprecations