### PR TITLE
Make evaluator OpenAI settings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ python browser_env/auto_login.py
 5. export `OPENAI_API_KEY=your_key`, a valid OpenAI API key starts with `sk-`
    The LLM-based evaluators use the same key by default. To run the evaluator
    against a different OpenAI-compatible endpoint or model, set
-   `WEBARENA_EVAL_OPENAI_API_KEY`, `WEBARENA_EVAL_OPENAI_API_BASE`, and
-   `WEBARENA_EVAL_MODEL`.
+   `WEBARENA_EVAL_OPENAI_API_KEY`, `WEBARENA_EVAL_OPENAI_API_BASE`,
+   `WEBARENA_EVAL_OPENAI_ORGANIZATION`, and `WEBARENA_EVAL_MODEL`.
 
 6. Launch the evaluation
 ```bash

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ python browser_env/auto_login.py
 ```
 5. export `OPENAI_API_KEY=your_key`, a valid OpenAI API key starts with `sk-`
    The LLM-based evaluators use the same key by default. To run the evaluator
-   against a different OpenAI-compatible endpoint or model, set
+   against a different OpenAI-compatible endpoint or model while the agent
+   still uses the regular `OPENAI_*` settings, set
    `WEBARENA_EVAL_OPENAI_API_KEY`, `WEBARENA_EVAL_OPENAI_API_BASE`,
    `WEBARENA_EVAL_OPENAI_ORGANIZATION`, and `WEBARENA_EVAL_MODEL`.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ mkdir -p ./.auth
 python browser_env/auto_login.py
 ```
 5. export `OPENAI_API_KEY=your_key`, a valid OpenAI API key starts with `sk-`
+   The LLM-based evaluators use the same key by default. To run the evaluator
+   against a different OpenAI-compatible endpoint or model, set
+   `WEBARENA_EVAL_OPENAI_API_KEY`, `WEBARENA_EVAL_OPENAI_API_BASE`, and
+   `WEBARENA_EVAL_MODEL`.
 
 6. Launch the evaluation
 ```bash

--- a/evaluation_harness/helper_functions.py
+++ b/evaluation_harness/helper_functions.py
@@ -16,7 +16,7 @@ from browser_env.env_config import (
     WIKIPEDIA,
 )
 from llms.providers.openai_utils import (
-    generate_from_openai_chat_completion,
+    generate_from_openai_eval_chat_completion,
 )
 
 
@@ -158,8 +158,7 @@ def llm_fuzzy_match(pred: str, reference: str, question: str) -> float:
         {"role": "user", "content": message},
     ]
 
-    response = generate_from_openai_chat_completion(
-        model="gpt-4-1106-preview",
+    response = generate_from_openai_eval_chat_completion(
         messages=messages,
         temperature=0,
         max_tokens=768,
@@ -193,8 +192,7 @@ def llm_ua_match(pred: str, reference: str, question: str) -> float:
         {"role": "user", "content": message},
     ]
 
-    response = generate_from_openai_chat_completion(
-        model="gpt-4-1106-preview",
+    response = generate_from_openai_eval_chat_completion(
         messages=messages,
         temperature=0,
         max_tokens=768,

--- a/llms/__init__.py
+++ b/llms/__init__.py
@@ -2,6 +2,7 @@
 from .providers.hf_utils import generate_from_huggingface_completion
 from .providers.openai_utils import (
     generate_from_openai_chat_completion,
+    generate_from_openai_eval_chat_completion,
     generate_from_openai_completion,
 )
 from .utils import call_llm
@@ -9,6 +10,7 @@ from .utils import call_llm
 __all__ = [
     "generate_from_openai_completion",
     "generate_from_openai_chat_completion",
+    "generate_from_openai_eval_chat_completion",
     "generate_from_huggingface_completion",
     "call_llm",
 ]

--- a/llms/providers/openai_utils.py
+++ b/llms/providers/openai_utils.py
@@ -14,6 +14,78 @@ import openai.error
 from tqdm.asyncio import tqdm_asyncio
 
 
+def _read_env_var(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return None
+    return value
+
+
+def _configure_openai(
+    api_key_env_var: str = "OPENAI_API_KEY",
+    api_base_env_var: str = "OPENAI_API_BASE",
+    organization_env_var: str = "OPENAI_ORGANIZATION",
+    fallback_api_key_env_var: str | None = None,
+    fallback_api_base_env_var: str | None = None,
+    fallback_organization_env_var: str | None = None,
+) -> None:
+    api_key = _read_env_var(api_key_env_var)
+    if api_key is None and fallback_api_key_env_var is not None:
+        api_key = _read_env_var(fallback_api_key_env_var)
+    if api_key is None:
+        expected_env = api_key_env_var
+        if fallback_api_key_env_var is not None:
+            expected_env = f"{api_key_env_var} or {fallback_api_key_env_var}"
+        raise ValueError(
+            f"{expected_env} environment variable must be set when using OpenAI API."
+        )
+
+    openai.api_key = api_key
+    organization = _read_env_var(organization_env_var)
+    if organization is None and fallback_organization_env_var is not None:
+        organization = _read_env_var(fallback_organization_env_var)
+    openai.organization = organization or ""
+
+    api_base = _read_env_var(api_base_env_var)
+    if api_base is None and fallback_api_base_env_var is not None:
+        api_base = _read_env_var(fallback_api_base_env_var)
+    if api_base is not None:
+        openai.api_base = api_base
+    else:
+        openai.api_base = "https://api.openai.com/v1"
+
+
+def _supports_custom_temperature(model: str) -> bool:
+    model_name = model.lower()
+    return not (
+        model_name.startswith("gpt-5")
+        or model_name.startswith("o1")
+        or model_name.startswith("o3")
+        or model_name.startswith("o4")
+    )
+
+
+def _chat_completion_kwargs(
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+    top_p: float,
+    stop_token: str | None = None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "top_p": top_p,
+    }
+    if _supports_custom_temperature(model):
+        kwargs["temperature"] = temperature
+    if stop_token:
+        kwargs["stop"] = [stop_token]
+    return kwargs
+
+
 def retry_with_exponential_backoff(  # type: ignore
     func,
     initial_delay: float = 1,
@@ -108,12 +180,7 @@ async def agenerate_from_openai_completion(
     Returns:
         List of generated responses.
     """
-    if "OPENAI_API_KEY" not in os.environ:
-        raise ValueError(
-            "OPENAI_API_KEY environment variable must be set when using OpenAI API."
-        )
-    openai.api_key = os.environ["OPENAI_API_KEY"]
-    openai.organization = os.environ.get("OPENAI_ORGANIZATION", "")
+    _configure_openai()
 
     limiter = aiolimiter.AsyncLimiter(requests_per_minute)
     async_responses = [
@@ -141,12 +208,7 @@ def generate_from_openai_completion(
     context_length: int,
     stop_token: str | None = None,
 ) -> str:
-    if "OPENAI_API_KEY" not in os.environ:
-        raise ValueError(
-            "OPENAI_API_KEY environment variable must be set when using OpenAI API."
-        )
-    openai.api_key = os.environ["OPENAI_API_KEY"]
-    openai.organization = os.environ.get("OPENAI_ORGANIZATION", "")
+    _configure_openai()
     response = openai.Completion.create(  # type: ignore
         prompt=prompt,
         engine=engine,
@@ -171,11 +233,13 @@ async def _throttled_openai_chat_completion_acreate(
         for _ in range(3):
             try:
                 return await openai.ChatCompletion.acreate(  # type: ignore
-                    model=model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    top_p=top_p,
+                    **_chat_completion_kwargs(
+                        model=model,
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        top_p=top_p,
+                    ),
                 )
             except openai.error.RateLimitError:
                 logging.warning(
@@ -213,12 +277,7 @@ async def agenerate_from_openai_chat_completion(
     Returns:
         List of generated responses.
     """
-    if "OPENAI_API_KEY" not in os.environ:
-        raise ValueError(
-            "OPENAI_API_KEY environment variable must be set when using OpenAI API."
-        )
-    openai.api_key = os.environ["OPENAI_API_KEY"]
-    openai.organization = os.environ.get("OPENAI_ORGANIZATION", "")
+    _configure_openai()
 
     limiter = aiolimiter.AsyncLimiter(requests_per_minute)
     async_responses = [
@@ -245,24 +304,60 @@ def generate_from_openai_chat_completion(
     top_p: float,
     context_length: int,
     stop_token: str | None = None,
+    api_key_env_var: str = "OPENAI_API_KEY",
+    api_base_env_var: str = "OPENAI_API_BASE",
+    organization_env_var: str = "OPENAI_ORGANIZATION",
+    fallback_api_key_env_var: str | None = None,
+    fallback_api_base_env_var: str | None = None,
+    fallback_organization_env_var: str | None = None,
 ) -> str:
-    if "OPENAI_API_KEY" not in os.environ:
-        raise ValueError(
-            "OPENAI_API_KEY environment variable must be set when using OpenAI API."
-        )
-    openai.api_key = os.environ["OPENAI_API_KEY"]
-    openai.organization = os.environ.get("OPENAI_ORGANIZATION", "")
+    _configure_openai(
+        api_key_env_var=api_key_env_var,
+        api_base_env_var=api_base_env_var,
+        organization_env_var=organization_env_var,
+        fallback_api_key_env_var=fallback_api_key_env_var,
+        fallback_api_base_env_var=fallback_api_base_env_var,
+        fallback_organization_env_var=fallback_organization_env_var,
+    )
 
     response = openai.ChatCompletion.create(  # type: ignore
-        model=model,
-        messages=messages,
-        temperature=temperature,
-        max_tokens=max_tokens,
-        top_p=top_p,
-        stop=[stop_token] if stop_token else None,
+        **_chat_completion_kwargs(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            stop_token=stop_token,
+        ),
     )
     answer: str = response["choices"][0]["message"]["content"]
     return answer
+
+
+def generate_from_openai_eval_chat_completion(
+    messages: list[dict[str, str]],
+    model: str | None = None,
+    temperature: float = 0,
+    max_tokens: int = 768,
+    top_p: float = 1.0,
+    context_length: int = 0,
+    stop_token: str | None = None,
+) -> str:
+    return generate_from_openai_chat_completion(
+        messages=messages,
+        model=model or os.environ.get("WEBARENA_EVAL_MODEL", "gpt-4-1106-preview"),
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        context_length=context_length,
+        stop_token=stop_token,
+        api_key_env_var="WEBARENA_EVAL_OPENAI_API_KEY",
+        api_base_env_var="WEBARENA_EVAL_OPENAI_API_BASE",
+        organization_env_var="WEBARENA_EVAL_OPENAI_ORGANIZATION",
+        fallback_api_key_env_var="OPENAI_API_KEY",
+        fallback_api_base_env_var="OPENAI_API_BASE",
+        fallback_organization_env_var="OPENAI_ORGANIZATION",
+    )
 
 
 @retry_with_exponential_backoff
@@ -276,11 +371,6 @@ def fake_generate_from_openai_chat_completion(
     context_length: int,
     stop_token: str | None = None,
 ) -> str:
-    if "OPENAI_API_KEY" not in os.environ:
-        raise ValueError(
-            "OPENAI_API_KEY environment variable must be set when using OpenAI API."
-        )
-    openai.api_key = os.environ["OPENAI_API_KEY"]
-    openai.organization = os.environ.get("OPENAI_ORGANIZATION", "")
+    _configure_openai()
     answer = "Let's think step-by-step. This page shows a list of links and buttons. There is a search box with the label 'Search query'. I will click on the search box to type the query. So the action I will perform is \"click [60]\"."
     return answer

--- a/llms/providers/openai_utils.py
+++ b/llms/providers/openai_utils.py
@@ -77,10 +77,13 @@ def _chat_completion_kwargs(
         "model": model,
         "messages": messages,
         "max_tokens": max_tokens,
-        "top_p": top_p,
     }
-    if _supports_custom_temperature(model):
+    supports_sampling_overrides = _supports_custom_temperature(model)
+    if supports_sampling_overrides:
         kwargs["temperature"] = temperature
+        kwargs["top_p"] = top_p
+    elif top_p != 1.0:
+        kwargs["top_p"] = top_p
     if stop_token:
         kwargs["stop"] = [stop_token]
     return kwargs

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -51,6 +51,32 @@ def test_gpt5_chat_completion_omits_custom_temperature(
     )
 
     assert "temperature" not in calls[0]
+    assert "top_p" not in calls[0]
+
+
+def test_gpt5_chat_completion_keeps_non_default_top_p(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        return {"choices": [{"message": {"content": "same"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "action-key")
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    openai_utils.generate_from_openai_chat_completion(
+        messages=[{"role": "user", "content": "hello"}],
+        model="gpt-5-mini",
+        temperature=0,
+        max_tokens=16,
+        top_p=0.5,
+        context_length=0,
+    )
+
+    assert "temperature" not in calls[0]
+    assert calls[0]["top_p"] == 0.5
 
 
 def test_eval_chat_completion_falls_back_to_default_key(

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,0 +1,95 @@
+import openai
+import pytest
+
+from llms.providers import openai_utils
+
+
+def test_eval_chat_completion_uses_separate_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        return {"choices": [{"message": {"content": "correct"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "action-key")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://action.example/v1")
+    monkeypatch.setenv("WEBARENA_EVAL_OPENAI_API_KEY", "eval-key")
+    monkeypatch.setenv("WEBARENA_EVAL_OPENAI_API_BASE", "https://eval.example/v1")
+    monkeypatch.setenv("WEBARENA_EVAL_MODEL", "gpt-4.1-mini")
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    response = openai_utils.generate_from_openai_eval_chat_completion(
+        messages=[{"role": "user", "content": "grade this"}],
+    )
+
+    assert response == "correct"
+    assert openai.api_key == "eval-key"
+    assert openai.api_base == "https://eval.example/v1"
+    assert calls[0]["model"] == "gpt-4.1-mini"
+    assert calls[0]["temperature"] == 0
+
+
+def test_gpt5_chat_completion_omits_custom_temperature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        return {"choices": [{"message": {"content": "same"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "action-key")
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    openai_utils.generate_from_openai_chat_completion(
+        messages=[{"role": "user", "content": "hello"}],
+        model="gpt-5-mini",
+        temperature=0,
+        max_tokens=16,
+        top_p=1.0,
+        context_length=0,
+    )
+
+    assert "temperature" not in calls[0]
+
+
+def test_eval_chat_completion_falls_back_to_default_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_create(**kwargs):
+        return {"choices": [{"message": {"content": "correct"}}]}
+
+    monkeypatch.delenv("WEBARENA_EVAL_OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "action-key")
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    response = openai_utils.generate_from_openai_eval_chat_completion(
+        messages=[{"role": "user", "content": "grade this"}],
+    )
+
+    assert response == "correct"
+    assert openai.api_key == "action-key"
+
+
+def test_default_openai_base_is_restored_when_no_base_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "action-key")
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    openai.api_base = "https://previous.example/v1"
+
+    def fake_create(**kwargs):
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+    response = openai_utils.generate_from_openai_chat_completion(
+        messages=[{"role": "user", "content": "hello"}],
+        model="gpt-4.1-mini",
+        temperature=0,
+        max_tokens=16,
+        top_p=1.0,
+        context_length=0,
+    )
+
+    assert response == "ok"
+    assert openai.api_base == "https://api.openai.com/v1"


### PR DESCRIPTION
## Summary
- add configurable OpenAI settings for LLM-based evaluators via `WEBARENA_EVAL_OPENAI_API_KEY`, `WEBARENA_EVAL_OPENAI_API_BASE`, `WEBARENA_EVAL_OPENAI_ORGANIZATION`, and `WEBARENA_EVAL_MODEL`
- preserve existing behavior by falling back to `OPENAI_API_KEY`, `OPENAI_API_BASE`, and `OPENAI_ORGANIZATION` when evaluator-specific env vars are not set
- omit custom temperature and default `top_p=1.0` for GPT-5/o-series chat models that reject non-default sampling parameters
- document evaluator env vars and add focused request-construction tests

Fixes #242
/claim #242

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_openai_utils.py -q` - 5 passed
- `python -m compileall llms/providers/openai_utils.py evaluation_harness/helper_functions.py llms/__init__.py tests/test_openai_utils.py`
- `git diff --check`

Note: I also attempted `python -m pip install -r requirements.txt`, but the pinned old native dependencies fail to build on this Python 3.12 macOS environment (`greenlet==2.0.1` and `tokenizers==0.13.3`). The targeted test path was run after installing the minimal imports needed by the project conftest.
