### PR TITLE
Fix element viewport ratio calculation

### DIFF
--- a/browser_env/processors.py
+++ b/browser_env/processors.py
@@ -1,7 +1,6 @@
-import json
 import re
 from collections import defaultdict
-from typing import Any, TypedDict, Union
+from typing import Any, TypedDict
 
 import numpy as np
 import numpy.typing as npt
@@ -136,7 +135,7 @@ class TextObervationProcessor(ObservationProcessor):
                 },
             )
             return response
-        except Exception as e:
+        except Exception:
             return {"result": {"subtype": "error"}}
 
     @staticmethod
@@ -167,8 +166,11 @@ class TextObervationProcessor(ObservationProcessor):
             - max(elem_top_bound, win_top_bound),
         )
 
-        # Compute the overlap area
-        ratio = overlap_width * overlap_height / width * height
+        if width <= 0 or height <= 0:
+            return 0.0
+
+        # Compute the fraction of the element's area that is in the viewport.
+        ratio = overlap_width * overlap_height / (width * height)
         return ratio
 
     def fetch_page_html(
@@ -346,7 +348,7 @@ class TextObervationProcessor(ObservationProcessor):
                     }
                     tree_str += f"{indent}{node_str}\n"
 
-            except Exception as e:
+            except Exception:
                 valid_node = False
 
             for child_ids in node["childIds"]:
@@ -536,7 +538,7 @@ class TextObervationProcessor(ObservationProcessor):
                         "text": node_str,
                     }
 
-            except Exception as e:
+            except Exception:
                 valid_node = False
 
             for _, child_node_id in enumerate(node["childIds"]):
@@ -659,7 +661,7 @@ class ImageObservationProcessor(ObservationProcessor):
     def process(self, page: Page, client: CDPSession) -> npt.NDArray[np.uint8]:
         try:
             screenshot = png_bytes_to_numpy(page.screenshot())
-        except:
+        except Exception:
             page.wait_for_event("load")
             screenshot = png_bytes_to_numpy(page.screenshot())
         return screenshot

--- a/tests/test_browser_env/test_processors.py
+++ b/tests/test_browser_env/test_processors.py
@@ -1,0 +1,52 @@
+from browser_env.processors import TextObervationProcessor
+
+
+VIEWPORT = {"win_width": 100, "win_height": 100}
+
+
+def test_element_fully_inside_viewport_ratio_is_one() -> None:
+    ratio = TextObervationProcessor.get_element_in_viewport_ratio(
+        elem_left_bound=10,
+        elem_top_bound=10,
+        width=20,
+        height=30,
+        config=VIEWPORT,
+    )
+
+    assert ratio == 1.0
+
+
+def test_element_partially_inside_viewport_ratio_uses_element_area() -> None:
+    ratio = TextObervationProcessor.get_element_in_viewport_ratio(
+        elem_left_bound=90,
+        elem_top_bound=80,
+        width=20,
+        height=40,
+        config=VIEWPORT,
+    )
+
+    assert ratio == 0.25
+
+
+def test_element_outside_viewport_ratio_is_zero() -> None:
+    ratio = TextObervationProcessor.get_element_in_viewport_ratio(
+        elem_left_bound=120,
+        elem_top_bound=120,
+        width=20,
+        height=40,
+        config=VIEWPORT,
+    )
+
+    assert ratio == 0.0
+
+
+def test_zero_area_element_ratio_is_zero() -> None:
+    ratio = TextObervationProcessor.get_element_in_viewport_ratio(
+        elem_left_bound=10,
+        elem_top_bound=10,
+        width=0,
+        height=40,
+        config=VIEWPORT,
+    )
+
+    assert ratio == 0.0


### PR DESCRIPTION
## Summary
- fix `get_element_in_viewport_ratio` to divide overlap area by element area
- return `0.0` for zero-area elements instead of dividing by zero
- add focused tests for fully visible, partially clipped, offscreen, and zero-area elements
- clean small lint issues in `browser_env/processors.py` touched by the fix

Fixes #178
/claim #178

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_browser_env/test_processors.py -q`
- `python -m compileall browser_env/processors.py tests/test_browser_env/test_processors.py`
- `python -m ruff check browser_env/processors.py tests/test_browser_env/test_processors.py`
- `git diff --check`