### PR TITLE
Handle missing HuggingFace model tag

### DIFF
--- a/agent/prompts/prompt_constructor.py
+++ b/agent/prompts/prompt_constructor.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from typing import Any, TypedDict
 
-from browser_env import Action, ActionParsingError, Trajectory
+from browser_env import ActionParsingError, Trajectory
 from browser_env.env_config import URL_MAPPINGS
 from browser_env.utils import StateInfo
 from llms import lm_config
@@ -103,8 +103,10 @@ class PromptConstructor(object):
                 else:
                     raise ValueError("Only chat mode is supported for Llama-2")
             else:
+                model_tag = self.lm_config.gen_config.get("model_tag", self.lm_config.model)
                 raise ValueError(
-                    f"Huggingface models do not support model_tag {self.lm_config.gen_config['model_tag']}"
+                    "Huggingface models only support Llama-2 chat prompts in "
+                    f"this prompt constructor, got model_tag {model_tag}"
                 )
         else:
             raise NotImplementedError(
@@ -187,7 +189,7 @@ class DirectPromptConstructor(PromptConstructor):
         )
 
         # make sure all keywords are replaced
-        assert all([f"{{k}}" not in current for k in keywords])
+        assert all(["{k}" not in current for k in keywords])
         prompt = self.get_lm_api_input(intro, examples, current)
         return prompt
 
@@ -242,7 +244,7 @@ class CoTPromptConstructor(PromptConstructor):
             previous_action=previous_action_str,
         )
 
-        assert all([f"{{k}}" not in current for k in keywords])
+        assert all(["{k}" not in current for k in keywords])
 
         prompt = self.get_lm_api_input(intro, examples, current)
         return prompt

--- a/tests/test_prompt_constructor.py
+++ b/tests/test_prompt_constructor.py
@@ -1,0 +1,46 @@
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_prompt_constructor():
+    for env_var in [
+        "REDDIT",
+        "SHOPPING",
+        "SHOPPING_ADMIN",
+        "GITLAB",
+        "WIKIPEDIA",
+        "MAP",
+        "HOMEPAGE",
+    ]:
+        os.environ.setdefault(env_var, f"http://{env_var.lower()}.example")
+
+    module_path = Path("agent/prompts/prompt_constructor.py")
+    tokenizers_module = types.ModuleType("llms.tokenizers")
+    tokenizers_module.Tokenizer = object
+    sys.modules["llms.tokenizers"] = tokenizers_module
+
+    spec = importlib.util.spec_from_file_location("prompt_constructor_under_test", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.PromptConstructor
+
+
+def test_huggingface_prompt_constructor_without_model_tag_raises_value_error() -> None:
+    prompt_constructor = _load_prompt_constructor()
+    constructor = prompt_constructor.__new__(prompt_constructor)
+    constructor.lm_config = SimpleNamespace(
+        provider="huggingface",
+        model="microsoft/phi-2",
+        mode="chat",
+        gen_config={},
+    )
+
+    with pytest.raises(ValueError, match="microsoft/phi-2"):
+        constructor.get_lm_api_input("intro", [("observation", "action")], "current")


### PR DESCRIPTION
## Summary
- avoid `KeyError` when a HuggingFace config does not define `model_tag`
- fall back to the configured model name in the unsupported-model error
- add a regression test for HuggingFace configs missing `model_tag`
- clean small lint issues in the touched prompt constructor

Fixes #221
/claim #221

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_prompt_constructor.py -q`
- `python -m ruff check agent/prompts/prompt_constructor.py tests/test_prompt_constructor.py`
- `python -m compileall agent/prompts/prompt_constructor.py tests/test_prompt_constructor.py`
- `git diff --check`