### PR TITLE
Fix Reddit task ground truth URLs

### DIFF
--- a/config_files/test.raw.json
+++ b/config_files/test.raw.json
@@ -12751,7 +12751,7 @@
       "reference_url": "",
       "program_html": [
         {
-          "url": "__REDDIT__/f/deeplearning/124993/meta-s-llama-weights-leaked-on-torrent-and-the-best-thing",
+          "url": "__REDDIT__/f/deeplearning/125036/should-i-continue-with-this",
           "locator": "document.querySelector('div.submission__vote').querySelector('form').getAttribute('class')",
           "required_contents": {
             "must_include": [
@@ -12786,7 +12786,7 @@
       "reference_url": "",
       "program_html": [
         {
-          "url": "__REDDIT__/f/explainlikeimfive/39244/eli5-how-does-pinching-a-ribbon-and-sliding-your-finger",
+          "url": "__REDDIT__/f/explainlikeimfive/125342/eli5-why-does-pressing-my-palms-against-my-eyes-create-a",
           "locator": "document.querySelector('div.submission__vote').querySelector('form').getAttribute('class')",
           "required_contents": {
             "must_include": [
@@ -19317,7 +19317,7 @@
       "reference_url": "",
       "program_html": [
         {
-          "url": "__REDDIT__/f/Karaoke",
+          "url": "__REDDIT__/f/Karaoke/edit",
           "locator": "document.querySelector(\"#forum_description\").value",
           "required_contents": {
             "must_include": [
@@ -19326,7 +19326,7 @@
           }
         },
         {
-          "url": "__REDDIT__/f/Karaoke",
+          "url": "__REDDIT__/f/Karaoke/edit",
           "locator": "document.querySelector(\"#forum_sidebar\").value",
           "required_contents": {
             "must_include": [

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+
+def test_reddit_task_ground_truth_urls_match_issue_246() -> None:
+    config_path = Path(__file__).resolve().parents[1] / "config_files" / "test.raw.json"
+    tasks = {task["task_id"]: task for task in json.loads(config_path.read_text())}
+
+    expected_urls = {
+        407: ["__REDDIT__/f/deeplearning/125036/should-i-continue-with-this"],
+        408: [
+            "__REDDIT__/f/explainlikeimfive/125342/eli5-why-does-pressing-my-palms-against-my-eyes-create-a"
+        ],
+        584: ["__REDDIT__/f/Karaoke/edit", "__REDDIT__/f/Karaoke/edit"],
+    }
+
+    for task_id, expected in expected_urls.items():
+        urls = [
+            check["url"]
+            for check in tasks[task_id]["eval"]["program_html"]
+        ]
+        assert urls == expected


### PR DESCRIPTION
## Summary
- update Reddit task 407 to evaluate the newest deeplearning post identified in #246
- update Reddit task 408 to evaluate the newest explainlikeimfive post identified in #246
- update Reddit task 584 to check the forum edit page fields
- add a regression test for these task URL expectations

Fixes #246
/claim #246

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_config_files.py -q`
- `python -m ruff check tests/test_config_files.py`
- `python -m compileall tests/test_config_files.py`
- `git diff --check`