### PR TITLE
Fix task 102 reference URL

### DIFF
--- a/config_files/test.raw.json
+++ b/config_files/test.raw.json
@@ -3289,7 +3289,7 @@
         "url_match"
       ],
       "reference_answers": null,
-      "reference_url": "__GITLAB__/byteblaze/a11y-syntax-highlighting/-/issues/?label_name%5B%5D=help%20wanted",
+      "reference_url": "__GITLAB__/a11yproject/a11yproject.com/-/issues/?label_name%5B%5D=help%20wanted",
       "program_html": [],
       "url_note": "GOLD in PRED"
     },

--- a/tests/test_task_102_reference_url.py
+++ b/tests/test_task_102_reference_url.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+
+def test_task_102_reference_url_matches_requested_repo() -> None:
+    config_path = Path(__file__).resolve().parents[1] / "config_files" / "test.raw.json"
+    tasks = {task["task_id"]: task for task in json.loads(config_path.read_text())}
+
+    task = tasks[102]
+
+    assert task["instantiation_dict"]["repo"] == "a11yproject/a11yproject.com"
+    assert (
+        task["eval"]["reference_url"]
+        == "__GITLAB__/a11yproject/a11yproject.com/-/issues/?label_name%5B%5D=help%20wanted"
+    )


### PR DESCRIPTION
## Summary
- update task 102 so the GitLab reference URL matches the requested `a11yproject/a11yproject.com` repository
- keep the existing help-wanted label query unchanged
- add a regression test for the task 102 repo/reference URL alignment

Fixes #218
/claim #218

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_task_102_reference_url.py -q`
- `python -m ruff check tests/test_task_102_reference_url.py`
- `python -m compileall tests/test_task_102_reference_url.py`
- `git diff --check`