### PR TITLE
Fix task 45 issue sort order

### DIFF
--- a/config_files/test.raw.json
+++ b/config_files/test.raw.json
@@ -1447,7 +1447,7 @@
         "url_match"
       ],
       "reference_answers": null,
-      "reference_url": "__GITLAB__/a11yproject/a11yproject.com/-/issues/?sort=created_asc&state=opened",
+      "reference_url": "__GITLAB__/a11yproject/a11yproject.com/-/issues/?sort=created_desc&state=opened",
       "program_html": [],
       "url_note": "GOLD in PRED"
     },

--- a/tests/test_task_45_recent_issues_sort.py
+++ b/tests/test_task_45_recent_issues_sort.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+
+
+def test_task_45_sorts_open_issues_by_most_recent_first() -> None:
+    config_path = Path(__file__).resolve().parents[1] / "config_files" / "test.raw.json"
+    tasks = {task["task_id"]: task for task in json.loads(config_path.read_text())}
+
+    assert tasks[45]["intent"] == "Check out the most recent open issues"
+    assert (
+        tasks[45]["eval"]["reference_url"]
+        == "__GITLAB__/a11yproject/a11yproject.com/-/issues/?sort=created_desc&state=opened"
+    )


### PR DESCRIPTION
## Summary
- update task 45 to sort GitLab open issues by newest first
- keep the existing opened-state filter
- add a regression test for the task 45 reference URL

Fixes #135
/claim #135

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_task_45_recent_issues_sort.py -q`
- `python -m ruff check tests/test_task_45_recent_issues_sort.py`
- `python -m compileall tests/test_task_45_recent_issues_sort.py`
- `git diff --check`