### PR TITLE
Handle numeric string match answers

### DIFF
--- a/evaluation_harness/evaluators.py
+++ b/evaluation_harness/evaluators.py
@@ -2,12 +2,13 @@
 # answer string match
 import collections
 import html
-import importlib
 import json
+import re
 import time
 import urllib
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Tuple, Union
+from typing import Union
 
 from beartype import beartype
 from nltk.tokenize import word_tokenize
@@ -17,13 +18,8 @@ from browser_env.actions import Action
 from browser_env.utils import StateInfo
 from evaluation_harness.helper_functions import (
     PseudoPage,
-    gitlab_get_project_memeber_role,
     llm_fuzzy_match,
     llm_ua_match,
-    reddit_get_post_url,
-    shopping_get_latest_order_url,
-    shopping_get_sku_latest_review_author,
-    shopping_get_sku_latest_review_rating,
 )
 
 Trajectory = list[Union[Action, StateInfo]]
@@ -105,6 +101,19 @@ class StringEvaluator(Evaluator):
             and len(clean_ref) == 1
             and len(word_tokenize(clean_ref)) == 1
         ):
+            try:
+                ref_number = Decimal(clean_ref)
+            except InvalidOperation:
+                ref_number = None
+            if ref_number is not None:
+                for match in re.finditer(
+                    r"(?<![\w.])-?\$?\d+(?:\.\d+)?(?![\w.])",
+                    clean_pred,
+                ):
+                    pred_number = Decimal(match.group().replace("$", ""))
+                    if pred_number == ref_number:
+                        return 1.0
+                return 0.0
             tok_pred = word_tokenize(clean_pred)
             return float(clean_ref in tok_pred)
         else:

--- a/tests/test_string_evaluator.py
+++ b/tests/test_string_evaluator.py
@@ -1,0 +1,27 @@
+import os
+
+for env_var in [
+    "REDDIT",
+    "SHOPPING",
+    "SHOPPING_ADMIN",
+    "GITLAB",
+    "WIKIPEDIA",
+    "MAP",
+    "HOMEPAGE",
+]:
+    os.environ.setdefault(env_var, f"http://{env_var.lower()}.example")
+
+from evaluation_harness.evaluators import StringEvaluator  # noqa: E402
+
+
+def test_numeric_must_include_accepts_equivalent_currency_answer() -> None:
+    assert StringEvaluator.must_include("0", "$0.00", tokenize=True) == 1.0
+
+
+def test_numeric_must_include_keeps_single_digit_false_positive_guard() -> None:
+    assert StringEvaluator.must_include("0", "$10.00", tokenize=True) == 0.0
+    assert StringEvaluator.must_include("0", "20", tokenize=True) == 0.0
+
+
+def test_numeric_must_include_accepts_plain_zero_answer() -> None:
+    assert StringEvaluator.must_include("0", "0", tokenize=True) == 1.0


### PR DESCRIPTION
## Summary
- allow tokenized numeric `must_include` checks to accept equivalent numeric/currency answers such as `$0.00` for reference `0`
- preserve the existing single-token false-positive guard so `0` does not match `$10.00` or `20`
- add regression tests for the task 144-style zero answer case

Fixes #211
/claim #211

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_string_evaluator.py -q`
- `python -m ruff check evaluation_harness/evaluators.py tests/test_string_evaluator.py`
- `python -m compileall evaluation_harness/evaluators.py tests/test_string_evaluator.py`
- `git diff --check`