### PR TITLE
Ignore HTTPS errors during auto login

### DIFF
--- a/browser_env/auto_login.py
+++ b/browser_env/auto_login.py
@@ -19,6 +19,7 @@ from browser_env.env_config import (
 
 HEADLESS = True
 SLOW_MO = 0
+CHROMIUM_ARGS = ["--ignore-certificate-errors"]
 
 
 SITES = ["gitlab", "shopping", "shopping_admin", "reddit"]
@@ -41,8 +42,12 @@ def is_expired(
 
     context_manager = sync_playwright()
     playwright = context_manager.__enter__()
-    browser = playwright.chromium.launch(headless=True, slow_mo=SLOW_MO)
-    context = browser.new_context(storage_state=storage_state)
+    browser = playwright.chromium.launch(
+        headless=True, slow_mo=SLOW_MO, args=CHROMIUM_ARGS
+    )
+    context = browser.new_context(
+        storage_state=storage_state, ignore_https_errors=True
+    )
     page = context.new_page()
     page.goto(url)
     time.sleep(1)
@@ -61,8 +66,10 @@ def is_expired(
 def renew_comb(comb: list[str], auth_folder: str = "./.auth") -> None:
     context_manager = sync_playwright()
     playwright = context_manager.__enter__()
-    browser = playwright.chromium.launch(headless=HEADLESS)
-    context = browser.new_context()
+    browser = playwright.chromium.launch(
+        headless=HEADLESS, args=CHROMIUM_ARGS
+    )
+    context = browser.new_context(ignore_https_errors=True)
     page = context.new_page()
 
     if "shopping" in comb:

--- a/tests/test_auto_login_https.py
+++ b/tests/test_auto_login_https.py
@@ -1,0 +1,71 @@
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+for env_var in [
+    "REDDIT",
+    "SHOPPING",
+    "SHOPPING_ADMIN",
+    "GITLAB",
+    "WIKIPEDIA",
+    "MAP",
+    "HOMEPAGE",
+]:
+    os.environ.setdefault(env_var, f"http://{env_var.lower()}.example")
+
+from browser_env import auto_login  # noqa: E402
+
+
+def _mock_playwright() -> tuple[Mock, Mock, Mock]:
+    page = Mock()
+    page.url = "http://shopping.example/wishlist/"
+    page.content.return_value = ""
+
+    context = Mock()
+    context.new_page.return_value = page
+
+    browser = Mock()
+    browser.new_context.return_value = context
+
+    playwright = Mock()
+    playwright.chromium.launch.return_value = browser
+
+    manager = MagicMock()
+    manager.__enter__.return_value = playwright
+    return manager, playwright, browser
+
+
+def test_is_expired_ignores_https_errors_for_context(tmp_path: Path) -> None:
+    manager, playwright, browser = _mock_playwright()
+    storage_state = tmp_path / "existing-auth-state.json"
+    storage_state.write_text("{}")
+
+    with patch.object(auto_login, "sync_playwright", return_value=manager):
+        auto_login.is_expired(
+            storage_state,
+            "http://shopping.example/wishlist/",
+            "",
+        )
+
+    playwright.chromium.launch.assert_called_once_with(
+        headless=True,
+        slow_mo=auto_login.SLOW_MO,
+        args=auto_login.CHROMIUM_ARGS,
+    )
+    browser.new_context.assert_called_once_with(
+        storage_state=storage_state,
+        ignore_https_errors=True,
+    )
+
+
+def test_renew_comb_ignores_https_errors_for_context() -> None:
+    manager, playwright, browser = _mock_playwright()
+
+    with patch.object(auto_login, "sync_playwright", return_value=manager):
+        auto_login.renew_comb(["shopping"], auth_folder="/tmp")
+
+    playwright.chromium.launch.assert_called_once_with(
+        headless=auto_login.HEADLESS,
+        args=auto_login.CHROMIUM_ARGS,
+    )
+    browser.new_context.assert_called_once_with(ignore_https_errors=True)


### PR DESCRIPTION
## Summary
- launch Chromium for auto-login with `--ignore-certificate-errors`
- create auto-login contexts with `ignore_https_errors=True`
- add mock-based tests for both cookie renewal and expiration checks

Fixes #220
/claim #220

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python -m pytest tests/test_auto_login_https.py -q`
- `python -m ruff check browser_env/auto_login.py tests/test_auto_login_https.py`
- `python -m compileall browser_env/auto_login.py tests/test_auto_login_https.py`
- `git diff --check`