### PR TITLE
Document forum session cookie workaround

### DIFF
--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -174,6 +174,13 @@ docker run --name forum -p 9999:80 -d postmill-populated-exposed-withimg
 ```
 Now you can visit `http://<your-server-hostname>:9999/`.
 
+If you manually browse the shopping site and forum from the same hostname, both PHP applications may use the default `PHPSESSID` cookie name and overwrite each other's login session. Agent evaluation usually uses isolated storage states, but manual browser sessions can avoid the conflict by giving the forum a distinct PHP session name:
+
+```bash
+docker exec forum sh -c 'echo "session.name = REDDITSESSID" > /usr/local/etc/php/conf.d/zz-overrides.ini'
+docker restart forum
+```
+
 
 ### Gitlab Website
 

--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -181,6 +181,10 @@ docker exec forum sh -c 'echo "session.name = REDDITSESSID" > /usr/local/etc/php
 docker restart forum
 ```
 
+This `docker exec` override is written inside the running container. Repeat the
+command after recreating the forum container, or bake the same PHP override into
+your local image if you rebuild it.
+
 
 ### Gitlab Website
 


### PR DESCRIPTION
## Summary
- document why manual shopping/forum browsing can overwrite login cookies under the same hostname
- add a forum `session.name` override workaround using `REDDITSESSID`
- clarify that agent evaluation usually avoids this via isolated storage states
- note that the `docker exec` override is container-local and must be repeated after recreating the forum container unless baked into a local image

Fixes #249
/claim #249

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `python - <<'PY' ... PY` README assertion checked `PHPSESSID`, `REDDITSESSID`, the `session.name` command, `docker restart forum`, and the container-recreate caveat
- `git diff --check`
