### PR TITLE
Clarify supported Docker image sources

### DIFF
--- a/environment_docker/README.md
+++ b/environment_docker/README.md
@@ -122,6 +122,9 @@ docker run --name forum -p 9999:80 -d postmill-populated-exposed-withimg
 ## Individual Website
 We highly recommend setting up the environments with AMI introduced above, but we also list the steps to setting up individual websites below. This allows you to setup selected websites locally.
 
+> [!IMPORTANT]
+> Use the image tar links listed in this README as the supported sources for the WebArena website images. Docker Hub images under the `webarenaimages` namespace are not uploaded or maintained by the WebArena maintainers and should not be treated as official or latest.
+
 
 ### Shopping Website (OneStopShop)
 


### PR DESCRIPTION
## Summary
- document that the README image tar links are the supported WebArena website image sources
- clarify that Docker Hub images under `webarenaimages` are not uploaded or maintained by the WebArena maintainers
- warn users not to treat those Docker Hub images as official/latest

Fixes #231
/claim #231

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/U3xSkpanaVo8u1sT

## Validation
- `git show poofeth/docs/official-docker-image-sources-231:environment_docker/README.md | rg -n "webarenaimages|supported|official|Docker Hub|maintain"`
- `git diff --check`
